### PR TITLE
Work around WebKit bug with getBBox() on <use> elements.

### DIFF
--- a/src/highlighter/svg_highlighter.js
+++ b/src/highlighter/svg_highlighter.js
@@ -49,10 +49,23 @@ sre.SvgHighlighter.prototype.highlightNode = function(node) {
     node.style.color = this.colorString().foreground;
     return info;
   }
-  var bbox = node.getBBox();
-  var rect = document.createElementNS(
-      'http://www.w3.org/2000/svg', 'rect');
-  var padding = 40;
+  var rect = document.createElementNS('http://www.w3.org/2000/svg','rect');
+  var padding = 40, bbox;
+  if (node.nodeName === "use") {
+    //
+    //  WebKit has a bug where the x and y attributes for a <use> element
+    //  are not taken into account in the getBBox() call
+    //  (see https://code.google.com/p/chromium/issues/detail?id=512081)
+    //  so we temporarily wrap the <use> in a <g> and use getBBox() on that.
+    //
+    var g = document.createElementNS('http://www.w3.org/2000/svg','g');
+    node.parentNode.insertBefore(g,node);
+    g.appendChild(node);
+    bbox = g.getBBox();
+    g.parentNode.replaceChild(node,g);
+  } else {
+    bbox = node.getBBox();
+  }
   rect.setAttribute('x', bbox.x - padding);
   rect.setAttribute('y', bbox.y - padding);
   rect.setAttribute('width', bbox.width + 2 * padding);


### PR DESCRIPTION
This pull provides a work-around for the WebKit bug that is causing the problems with highlighting fences in issue #29.  The problem is that `getBBox()` doesn't take the `x` attribute into account, so you get the wrong placement of the highlight rectangle.  The work-around is to temporarily wrap the `<use>` element in a `<g>` and use `getBBox()` on that.  Ugly, but it seems to work for me.