### PR TITLE
Underover case

### DIFF
--- a/src/semantic_tree/semantic_attr.js
+++ b/src/semantic_tree/semantic_attr.js
@@ -1344,6 +1344,7 @@ sre.SemanticAttr.Role = {
   UNDERACCENT: 'underaccent',
 
   // Index and tensor roles.
+  UNDEROVER: 'underover',
   SUBSUP: 'subsup',
   LEFTSUB: 'leftsub',
   LEFTSUPER: 'leftsuper',

--- a/src/semantic_tree/semantic_tree.js
+++ b/src/semantic_tree/semantic_tree.js
@@ -1628,7 +1628,7 @@ sre.SemanticTree.prototype.makeLimitNode_ = function(mmlTag, children) {
         } else {
           innerNode = this.makeBranchNode_(sre.SemanticAttr.Type.UNDERSCORE,
                                            [center, children[1]], []);
-          innerNode.role = center.role;
+          innerNode.role = sre.SemanticAttr.Role.UNDEROVER;
           children = [innerNode, children[2]];
           type = sre.SemanticAttr.Type.OVERSCORE;
         }

--- a/tests/enrich_mathml_test.js
+++ b/tests/enrich_mathml_test.js
@@ -2913,7 +2913,7 @@ sre.EnrichMathmlTest.prototype.testMathmlSimpleFuncsSingle = function() {
       ' parent="10">' +
       '<mo type="fence" role="open" id="1" parent="8"' +
       ' operator="fenced">(</mo>' +
-      '<munderover type="latinletter" role="latinletter" id="6"' +
+      '<munderover type="underover" role="latinletter" id="6"' +
       ' children="2,3,4" parent="8" collapsed="(6 (5 2 3) 4)">' +
       '<mi type="identifier" role="latinletter" id="2" parent="6">x</mi>' +
       '<mn type="number" role="integer" id="3" parent="6">2</mn>' +
@@ -3965,7 +3965,7 @@ sre.EnrichMathmlTest.prototype.testMathmlPrefixFuncsSingle = function() {
       ' content="1,7" parent="10">' +
       '<mo type="fence" role="open" id="1" parent="8"' +
       ' operator="fenced">(</mo>' +
-      '<munderover type="latinletter" role="latinletter" id="6"' +
+      '<munderover type="underover" role="latinletter" id="6"' +
       ' children="2,3,4" parent="8" collapsed="(6 (5 2 3) 4)">' +
       '<mi type="identifier" role="latinletter" id="2" parent="6">x</mi>' +
       '<mn type="number" role="integer" id="3" parent="6">2</mn>' +
@@ -4760,7 +4760,7 @@ sre.EnrichMathmlTest.prototype.testMathmlPrefixFuncsUnfenced = function() {
       ' operator="appl">sin</mi>' +
       '<mo type="punctuation" role="application" id="6" parent="7"' +
       ' added="true" operator="appl">⁡</mo>' +
-      '<munderover type="latinletter" role="latinletter" id="5"' +
+      '<munderover type="underover" role="latinletter" id="5"' +
       ' children="1,2,3" parent="7" collapsed="(5 (4 1 2) 3)">' +
       '<mi type="identifier" role="latinletter" id="1" parent="5">x</mi>' +
       '<mn type="number" role="integer" id="2" parent="5">2</mn>' +
@@ -8979,7 +8979,7 @@ sre.EnrichMathmlTest.prototype.testMathmlMunderOver = function() {
       '<munderover><mo>&#x2192;</mo><mi>n</mi><mtext>above</mtext>' +
       '</munderover>',
       '<math>' +
-      '<munderover type="arrow" role="arrow" id="4" children="0,1,2"' +
+      '<munderover type="underover" role="arrow" id="4" children="0,1,2"' +
       ' collapsed="(4 (3 0 1) 2)">' +
       '<mo type="relation" role="arrow" id="0" parent="4">→</mo>' +
       '<mi type="identifier" role="latinletter" id="1" parent="4">n</mi>' +


### PR DESCRIPTION
Treatment of some underover cases similar to subsup.
Avoids redundant information in the type/role slots.