### PR TITLE
Adds semantic and annotation elements into the correct MathML element

### DIFF
--- a/src/common/externs.js
+++ b/src/common/externs.js
@@ -50,6 +50,8 @@ MathJax.Callback.Signal = function(signal) { };
 
 
 var wgxpath;
+
+
 /**
  * @type {function(Object=)}
  */

--- a/src/semantic_tree/semantic_tree.js
+++ b/src/semantic_tree/semantic_tree.js
@@ -544,6 +544,7 @@ sre.SemanticTree.prototype.parseMathml_ = function(mml) {
       break;
     case 'MS':
     case 'MTEXT':
+    case 'ANNOTATION-XML':
       newNode = this.makeLeafNode_(mml);
       newNode.type = sre.SemanticAttr.Type.TEXT;
       if (sre.SemanticUtil.tagName(mml) === 'MS') {
@@ -593,6 +594,7 @@ sre.SemanticTree.prototype.parseMathml_ = function(mml) {
     case 'MMULTISCRIPTS':
       newNode = this.processMultiScript_(children);
       break;
+    case 'ANNOTATION':
     case 'NONE':
       newNode = this.makeEmptyNode_();
       break;

--- a/src/semantic_tree/semantic_util.js
+++ b/src/semantic_tree/semantic_util.js
@@ -142,7 +142,7 @@ sre.SemanticUtil.LEAFTAGS = ['MO', 'MI', 'MN', 'MTEXT', 'MS'];
  */
 sre.SemanticUtil.IGNORETAGS = [
   'MERROR', 'MPHANTOM', 'MSPACE', 'MALIGNGROUP', 'MALIGNMARK',
-  'MPRESCRIPTS'
+  'MPRESCRIPTS', 'ANNOTATION', 'ANNOTATION-XML'
 ];
 
 
@@ -152,7 +152,7 @@ sre.SemanticUtil.IGNORETAGS = [
  * @const
  */
 sre.SemanticUtil.EMPTYTAGS = [
-  'MATH', 'MROW', 'MPADDED', 'MACTION', 'NONE', 'MSTYLE'
+  'MATH', 'MROW', 'MPADDED', 'MACTION', 'NONE', 'MSTYLE', 'SEMANTICS'
 ];
 
 

--- a/src/walker/abstract_walker.js
+++ b/src/walker/abstract_walker.js
@@ -68,7 +68,7 @@ sre.AbstractWalker = function(node, generator, highlighter, xml) {
    */
   this.rebuilt = this.rebuildStree_();
   this.generator.setRebuilt(this.rebuilt);
-  
+
   //TODO: This is problematic as it will sometimes not be instantiated if called
   //      from MathJax.
   /**
@@ -103,7 +103,7 @@ sre.AbstractWalker = function(node, generator, highlighter, xml) {
    * @type {!Node}
    */
   this.rootNode = sre.WalkerUtil.getSemanticRoot(node);
-  
+
   /**
    * The node that currently inspected. Initially this is the entire math
    * expression.

--- a/tests/enrich_mathml_test.js
+++ b/tests/enrich_mathml_test.js
@@ -66,15 +66,6 @@ sre.EnrichMathmlTest.prototype.executeMathmlTest = function(mml, smml) {
   var cleaned = sre.EnrichMathml.removeAttributePrefix(
       xmls.serializeToString(node));
   this.assert.equal(cleaned, xmls.serializeToString(xml));
-  //
-  // Code to replay the MathML enrichment on the enriched element.
-  // Currently this only works on relatively simple elements.
-  //
-  // if (cleaned.match(/role="implicit"|operator="fenced"/)) return;
-  // var node2 = sre.Semantic.enrichMathml(node.toString());
-  // var cleaned2 = sre.EnrichMathml.removeAttributePrefix(
-  //     xmls.serializeToString(node2));
-  // this.assert.equal(cleaned, cleaned2);
 };
 
 
@@ -10153,6 +10144,225 @@ sre.EnrichMathmlTest.prototype.testMathmlComplexEmbellRight = function() {
       '</mrow>' +
       '<mn type="number" role="integer" id="5" parent="6">4</mn>' +
       '</msub>' +
+      '</math>'
+  );
+};
+
+
+// Actions.
+/**
+ * Currently foreign Mactions do not work with the enrichment.
+ */
+sre.EnrichMathmlTest.prototype.untestMathmlActions = function() {
+  this.executeMathmlTest(
+      '<maction><mtext>something</mtext><mn>2</mn></maction>',
+      '<math>' +
+      '<maction><mtext>something</mtext>' +
+      '<mn type="number" role="integer" font="normal" id="0">2</mn>' +
+      '</maction>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<maction><mtext>something</mtext><mi>a</mi></maction>',
+      '<math>' +
+      '<maction><mtext>something</mtext>' +
+      '<mn type="identifier" role="latinletter" font="normal" id="0">a</mn>' +
+      '</maction>' +
+      '</math>'
+  );
+};
+
+
+// Semantics, annotation, annotation-xml
+/**
+ * Expressions with semantic elements.
+ */
+sre.EnrichMathmlTest.prototype.testSemanticsElement = function() {
+  this.executeMathmlTest(
+      '<semantics></semantics>',
+      '<math type="empty" role="unknown" id="0">' +
+      '<semantics/>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<semantics><mi>a</mi></semantics>',
+      '<math>' +
+      '<semantics>' +
+      '<mi type="identifier" role="latinletter" id="0">a</mi>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></semantics>',
+      '<math>' +
+      '<semantics>' +
+      '<mrow type="infixop" role="addition" id="3" children="0,2"' +
+      ' content="1">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="operator" role="addition" id="1" parent="3"' +
+      ' operator="infixop,+">+</mo>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="3">b</mi>' +
+      '</mrow>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mi>a</mi><mo>+</mo><semantics><mi>b</mi></semantics>',
+      '<math type="infixop" role="addition" id="3" children="0,2"' +
+      ' content="1">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="operator" role="addition" id="1" parent="3"' +
+      ' operator="infixop,+">+</mo>' +
+      '<semantics>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="3">b</mi>' +
+      '</semantics>' +
+      '</math>'
+  );
+};
+
+
+/**
+ * Expressions with semantic elements and annotations.
+ */
+sre.EnrichMathmlTest.prototype.testSemanticsAnnotation = function() {
+  // This is not really legal markup.
+  this.executeMathmlTest(
+      '<semantics><annotation>something</annotation></semantics>',
+      '<math>' +
+      '<semantics type="empty" role="unknown" id="0">' +
+      '<annotation>something</annotation>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mi>a</mi><semantics><annotation><content>something</content>' +
+      '</annotation></semantics>',
+      '<math>' +
+      '<mi type="identifier" role="latinletter" id="0">a</mi>' +
+      '<semantics>' +
+      '<annotation>' +
+      '<content>something</content>' +
+      '</annotation>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<semantics><mi>a</mi><annotation>something</annotation></semantics>',
+      '<math>' +
+      '<semantics>' +
+      '<mi type="identifier" role="latinletter" id="0">a</mi>' +
+      '<annotation>something</annotation>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>' +
+      '<annotation>something</annotation></semantics>',
+      '<math>' +
+      '<semantics>' +
+      '<mrow type="infixop" role="addition" id="3" children="0,2"' +
+      ' content="1">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="operator" role="addition" id="1" parent="3"' +
+      ' operator="infixop,+">+</mo>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="3">b</mi>' +
+      '</mrow>' +
+      '<annotation>something</annotation>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mi>a</mi><mo>+</mo><semantics><mi>b</mi>' +
+      '<annotation>something</annotation></semantics>',
+      '<math type="infixop" role="addition" id="3" children="0,2"' +
+      ' content="1">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="operator" role="addition" id="1" parent="3"' +
+      ' operator="infixop,+">+</mo>' +
+      '<semantics>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="3">b</mi>' +
+      '<annotation>something</annotation>' +
+      '</semantics>' +
+      '</math>'
+  );
+};
+
+
+/**
+ * Expressions with semantic elements and xml annotations.
+ */
+sre.EnrichMathmlTest.prototype.testSemanticsAnnotationXml = function() {
+  // This is not really legal markup.
+  this.executeMathmlTest(
+      '<semantics><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<math>' +
+      '<semantics type="text" role="unknown" id="0">' +
+      '<annotation-xml>' +
+      '<content>something</content>' +
+      '</annotation-xml>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mi>a</mi><semantics><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<math type="punctuated" role="text" id="3" children="0,1" content="2">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="punctuation" role="dummy" id="2" parent="3" added="true"' +
+      ' operator="punctuated">⁣</mo>' +
+      '<semantics type="text" role="unknown" id="1" parent="3">' +
+      '<annotation-xml>' +
+      '<content>something</content>' +
+      '</annotation-xml>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<semantics><mi>a</mi><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<math>' +
+      '<semantics>' +
+      '<mi type="identifier" role="latinletter" id="0">a</mi>' +
+      '<annotation-xml>' +
+      '<content>something</content>' +
+      '</annotation-xml>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>' +
+      '<annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<math>' +
+      '<semantics>' +
+      '<mrow type="infixop" role="addition" id="3" children="0,2"' +
+      ' content="1">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="operator" role="addition" id="1" parent="3"' +
+      ' operator="infixop,+">+</mo>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="3">b</mi>' +
+      '</mrow>' +
+      '<annotation-xml>' +
+      '<content>something</content>' +
+      '</annotation-xml>' +
+      '</semantics>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mi>a</mi><mo>+</mo><semantics><mi>b</mi><annotation-xml>' +
+      '<content>something</content></annotation-xml></semantics>',
+      '<math type="infixop" role="addition" id="3" children="0,2"' +
+      ' content="1">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="3">a</mi>' +
+      '<mo type="operator" role="addition" id="1" parent="3"' +
+      ' operator="infixop,+">+</mo>' +
+      '<semantics>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="3">b</mi>' +
+      '<annotation-xml>' +
+      '<content>something</content>' +
+      '</annotation-xml>' +
+      '</semantics>' +
       '</math>'
   );
 };

--- a/tests/mathspeak_embellish_test.js
+++ b/tests/mathspeak_embellish_test.js
@@ -371,3 +371,91 @@ sre.MathspeakEmbellishTest.prototype.testEmbellMultPunctSubscript = function() {
   this.executeRuleTest(mml, 'a colon Sub 2 Base b colon c', 'brief');
   this.executeRuleTest(mml, 'a colon Sub 2 Base b colon c', 'sbrief');
 };
+
+
+/**
+ * Expressions with semantic elements.
+ */
+sre.MathspeakEmbellishTest.prototype.testSemanticsElement = function() {
+  var mml = '<semantics></semantics>';
+  this.executeRuleTest(mml, '', 'default');
+  this.executeRuleTest(mml, '', 'brief');
+  this.executeRuleTest(mml, '', 'sbrief');
+  mml = '<semantics><mi>a</mi></semantics>';
+  this.executeRuleTest(mml, 'a', 'default');
+  this.executeRuleTest(mml, 'a', 'brief');
+  this.executeRuleTest(mml, 'a', 'sbrief');
+  mml = '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></semantics>';
+  this.executeRuleTest(mml, 'a plus b', 'default');
+  this.executeRuleTest(mml, 'a plus b', 'brief');
+  this.executeRuleTest(mml, 'a plus b', 'sbrief');
+  mml = '<mi>a</mi><mo>+</mo><semantics><mi>b</mi></semantics>';
+  this.executeRuleTest(mml, 'a plus b', 'default');
+  this.executeRuleTest(mml, 'a plus b', 'brief');
+  this.executeRuleTest(mml, 'a plus b', 'sbrief');
+};
+
+
+/**
+ * Expressions with semantic elements and annotations.
+ */
+sre.MathspeakEmbellishTest.prototype.testSemanticsAnnotation = function() {
+  // This is not really legal markup.
+  var mml = '<semantics><annotation>something</annotation></semantics>';
+  this.executeRuleTest(mml, '', 'default');
+  this.executeRuleTest(mml, '', 'brief');
+  this.executeRuleTest(mml, '', 'sbrief');
+  mml = '<mi>a</mi><semantics><annotation><content>something</content>' +
+      '</annotation></semantics>';
+  this.executeRuleTest(mml, 'a', 'default');
+  this.executeRuleTest(mml, 'a', 'brief');
+  this.executeRuleTest(mml, 'a', 'sbrief');
+  mml = '<semantics><mi>a</mi><annotation>something</annotation></semantics>';
+  this.executeRuleTest(mml, 'a', 'default');
+  this.executeRuleTest(mml, 'a', 'brief');
+  this.executeRuleTest(mml, 'a', 'sbrief');
+  mml = '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>' +
+      '<annotation>something</annotation></semantics>';
+  this.executeRuleTest(mml, 'a plus b', 'default');
+  this.executeRuleTest(mml, 'a plus b', 'brief');
+  this.executeRuleTest(mml, 'a plus b', 'sbrief');
+  mml = '<mi>a</mi><mo>+</mo><semantics><mi>b</mi>' +
+      '<annotation>something</annotation></semantics>';
+  this.executeRuleTest(mml, 'a plus b', 'default');
+  this.executeRuleTest(mml, 'a plus b', 'brief');
+  this.executeRuleTest(mml, 'a plus b', 'sbrief');
+};
+
+
+/**
+ * Expressions with semantic elements and xml annotations.
+ */
+sre.MathspeakEmbellishTest.prototype.testSemanticsAnnotationXml = function() {
+  // This is not really legal markup.
+  var mml = '<semantics><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>';
+  this.executeRuleTest(mml, 'something', 'default');
+  this.executeRuleTest(mml, 'something', 'brief');
+  this.executeRuleTest(mml, 'something', 'sbrief');
+  mml = '<mi>a</mi><semantics><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>';
+  this.executeRuleTest(mml, 'a something', 'default');
+  this.executeRuleTest(mml, 'a something', 'brief');
+  this.executeRuleTest(mml, 'a something', 'sbrief');
+  mml = '<semantics><mi>a</mi><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>';
+  this.executeRuleTest(mml, 'a', 'default');
+  this.executeRuleTest(mml, 'a', 'brief');
+  this.executeRuleTest(mml, 'a', 'sbrief');
+  mml = '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>' +
+      '<annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>';
+  this.executeRuleTest(mml, 'a plus b', 'default');
+  this.executeRuleTest(mml, 'a plus b', 'brief');
+  this.executeRuleTest(mml, 'a plus b', 'sbrief');
+  mml = '<mi>a</mi><mo>+</mo><semantics><mi>b</mi><annotation-xml>' +
+      '<content>something</content></annotation-xml></semantics>';
+  this.executeRuleTest(mml, 'a plus b', 'default');
+  this.executeRuleTest(mml, 'a plus b', 'brief');
+  this.executeRuleTest(mml, 'a plus b', 'sbrief');
+};

--- a/tests/semantic_tree_test.js
+++ b/tests/semantic_tree_test.js
@@ -9944,3 +9944,133 @@ sre.SemanticTreeTest.prototype.testStreeActions = function() {
       '<maction><mtext>something</mtext><mi>a</mi></maction>',
       '<identifier>a</identifier>');
 };
+
+
+// Semantics, annotation, annotation-xml
+/**
+ * Expressions with semantic elements.
+ */
+sre.SemanticTreeTest.prototype.testSemanticsElement = function() {
+  this.brief = true;
+  this.executeTreeTest(
+      '<semantics></semantics>',
+      '<empty/>'
+  );
+  this.executeTreeTest(
+      '<semantics><mi>a</mi></semantics>',
+      '<identifier>a</identifier>'
+  );
+  this.executeTreeTest(
+      '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></semantics>',
+      '<infixop>+' +
+      '<content><operator>+</operator></content>' +
+      '<children>' +
+      '<identifier>a</identifier>' +
+      '<identifier>b</identifier>' +
+      '</children>' +
+      '</infixop>'
+  );
+  this.executeTreeTest(
+      '<mi>a</mi><mo>+</mo><semantics><mi>b</mi></semantics>',
+      '<infixop>+' +
+      '<content><operator>+</operator></content>' +
+      '<children>' +
+      '<identifier>a</identifier>' +
+      '<identifier>b</identifier>' +
+      '</children>' +
+      '</infixop>'
+  );
+};
+
+
+/**
+ * Expressions with semantic elements and annotations.
+ */
+sre.SemanticTreeTest.prototype.testSemanticsAnnotation = function() {
+  this.brief = true;
+  // This is not really legal markup.
+  this.executeTreeTest(
+      '<semantics><annotation>something</annotation></semantics>',
+      '<empty/>'
+  );
+  this.executeTreeTest(
+      '<mi>a</mi><semantics><annotation><content>something</content>' +
+      '</annotation></semantics>',
+      '<identifier>a</identifier>'
+  );
+  this.executeTreeTest(
+      '<semantics><mi>a</mi><annotation>something</annotation></semantics>',
+      '<identifier>a</identifier>'
+  );
+  this.executeTreeTest(
+      '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>' +
+      '<annotation>something</annotation></semantics>',
+      '<infixop>+' +
+      '<content><operator>+</operator></content>' +
+      '<children>' +
+      '<identifier>a</identifier>' +
+      '<identifier>b</identifier>' +
+      '</children>' +
+      '</infixop>'
+  );
+  this.executeTreeTest(
+      '<mi>a</mi><mo>+</mo><semantics><mi>b</mi>' +
+      '<annotation>something</annotation></semantics>',
+      '<infixop>+' +
+      '<content><operator>+</operator></content>' +
+      '<children>' +
+      '<identifier>a</identifier>' +
+      '<identifier>b</identifier>' +
+      '</children>' +
+      '</infixop>'
+  );
+};
+
+
+/**
+ * Expressions with semantic elements and xml annotations.
+ */
+sre.SemanticTreeTest.prototype.testSemanticsAnnotationXml = function() {
+  this.brief = true;
+  // This is not really legal markup.
+  this.executeTreeTest(
+      '<semantics><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<text>something</text>'
+  );
+  this.executeTreeTest(
+      '<mi>a</mi><semantics><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<punctuated><content><punctuation>⁣</punctuation>' +
+      '</content><children><identifier>a</identifier>' +
+      '<text>something</text></children></punctuated>'
+  );
+  this.executeTreeTest(
+      '<semantics><mi>a</mi><annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<identifier>a</identifier>'
+  );
+  this.executeTreeTest(
+      '<semantics><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow>' +
+      '<annotation-xml><content>something</content>' +
+      '</annotation-xml></semantics>',
+      '<infixop>+' +
+      '<content><operator>+</operator></content>' +
+      '<children>' +
+      '<identifier>a</identifier>' +
+      '<identifier>b</identifier>' +
+      '</children>' +
+      '</infixop>'
+  );
+  this.executeTreeTest(
+      '<mi>a</mi><mo>+</mo><semantics><mi>b</mi><annotation-xml>' +
+      '<content>something</content></annotation-xml></semantics>',
+      '<infixop>+' +
+      '<content><operator>+</operator></content>' +
+      '<children>' +
+      '<identifier>a</identifier>' +
+      '<identifier>b</identifier>' +
+      '</children>' +
+      '</infixop>'
+  );
+};


### PR DESCRIPTION
categories. Thereby fixes the error if a semantic element has a singleton child
and an annotation.