### PR TITLE
Refactor focus

### DIFF
--- a/doc/diagram-project.org
+++ b/doc/diagram-project.org
@@ -46,8 +46,29 @@ Notes from the Diagram project
 
 ** Intoduces explicit semantic skeleton structure
 ** Handling explicit content nodes in skeleton with prefix c
-** Retains now role for indices in puncutation.
+** Retains now role for indices in punctuation.
 
+* Refactoring walking
+
+** focus are generated on semantic tree nodes
+
+** focus contains
+
+*** primary: semantic tree
+
+*** semantic-nodes: List of all nodes in the 
+
+*** nodes: existing DOM nodes. Can contain null.
+
+** Walking in general then happens on the semantic tree.
+
+** Speech generation: if null node, then
+
+*** try to get the node from semantic tree and
+
+*** the speech from the rebuilt tree.
+
+** Highlighting works on the existing nodes and potential children.
 
 * Testing ideas
 

--- a/doc/diagram-project.org
+++ b/doc/diagram-project.org
@@ -70,6 +70,11 @@ Notes from the Diagram project
 
 ** Highlighting works on the existing nodes and potential children.
 
+*** Recurse over children, if they do not have a DOM node until exhausted:
+
+*** Create focus from semantic nodes together with xml structure.
+
+
 * Testing ideas
 
 ** multiline equations

--- a/doc/diagram-project.org
+++ b/doc/diagram-project.org
@@ -74,6 +74,17 @@ Notes from the Diagram project
 
 *** Create focus from semantic nodes together with xml structure.
 
+* TODO
+
+** binomial coefficient bug
+** finish commenting rebuild stree
+** cleanup skeleton structure
+** refactor recompute speech
+** change semantic node id to string!
+** prefix for multi-index structures
+** cache problems with context
+** spaces (> normal)
+** labels
 
 * Testing ideas
 

--- a/src/walker/abstract_walker.js
+++ b/src/walker/abstract_walker.js
@@ -210,6 +210,7 @@ sre.AbstractWalker.prototype.speech = function() {
   }
   var speech = nodes.map(
       goog.bind(function(x) {
+        // HERE: Change speech generation to semantic node!
         return this.generator.getSpeech(x, this.xml);
       }, this));
   if (prefix) speech.unshift(prefix);
@@ -246,6 +247,7 @@ sre.AbstractWalker.prototype.move = function(key) {
     return false;
   }
   this.focus_ = focus;
+  console.log(this.focus_);
   return true;
 };
 
@@ -480,3 +482,30 @@ sre.AbstractWalker.prototype.nextLevel = function() {
  * @return {!Array.<T>} The list of focus elements.
  */
 sre.AbstractWalker.prototype.combineContentChildren = goog.abstractMethod;
+
+
+/**
+ * Creates a simple focus for a solitary node.
+ * @param {string} id The semantic id of the focus node.
+ * @return {!sre.Focus} A focus containing only this node and the other
+ *     properties of the old focus.
+ */
+sre.AbstractWalker.prototype.singletonFocus = function(id) {
+  var node = this.getBySemanticId(id);
+  return new sre.Focus([node], node);
+};
+
+
+/**
+ * Makes a focus for a primary node and a node list, all given by their ids.
+ * @param {string} id The semantic id of the primary node.
+ * @param {!Array.<string>} ids The semantic id of the node list.
+ * @return {!sre.Focus} The new focus.
+ */
+sre.AbstractWalker.prototype.focusFromId = function(id, ids) {
+  var node = this.getBySemanticId(id);
+  var nodes = ids.map(goog.bind(this.getBySemanticId, this));
+  return new sre.Focus(nodes, node);
+};
+
+

--- a/src/walker/abstract_walker.js
+++ b/src/walker/abstract_walker.js
@@ -247,7 +247,6 @@ sre.AbstractWalker.prototype.move = function(key) {
     return false;
   }
   this.focus_ = focus;
-  console.log(this.focus_);
   return true;
 };
 
@@ -344,7 +343,9 @@ sre.AbstractWalker.prototype.primaryAttribute = function(attr) {
  * @return {string} The id of the primary node of the current focus.
  */
 sre.AbstractWalker.prototype.primaryId = function() {
-  return this.primaryAttribute(sre.EnrichMathml.Attribute.ID);
+  var primary = this.focus_.getPrimary();
+  return primary ?
+      sre.WalkerUtil.getAttribute(primary, sre.EnrichMathml.Attribute.ID) : '';
 };
 
 
@@ -459,17 +460,13 @@ sre.AbstractWalker.prototype.previousLevel = function() {
  * @return {!Array.<T>} The next lower level.
  */
 sre.AbstractWalker.prototype.nextLevel = function() {
-  var children = sre.WalkerUtil.splitAttribute(
-      this.primaryAttribute(sre.EnrichMathml.Attribute.CHILDREN));
-  var content = sre.WalkerUtil.splitAttribute(
-      this.primaryAttribute(sre.EnrichMathml.Attribute.CONTENT));
+  var toIds = function(x) { return x.id.toString(); };
+  var snode = this.rebuilt.nodeDict[this.primaryId()];
+  var children = snode.childNodes.map(toIds);
+  var content = snode.contentNodes.map(toIds);
   if (children.length === 0) return [];
-  var type = this.primaryAttribute(sre.EnrichMathml.Attribute.TYPE);
-  var role = this.primaryAttribute(sre.EnrichMathml.Attribute.ROLE);
   return this.combineContentChildren(
-      /** @type {!sre.SemanticAttr.Type} */ (type),
-      /** @type {!sre.SemanticAttr.Role} */ (role),
-      content, children);
+      snode.type, snode.role, content, children);
 };
 
 
@@ -491,8 +488,7 @@ sre.AbstractWalker.prototype.combineContentChildren = goog.abstractMethod;
  *     properties of the old focus.
  */
 sre.AbstractWalker.prototype.singletonFocus = function(id) {
-  var node = this.getBySemanticId(id);
-  return new sre.Focus([node], node);
+  return this.focusFromId(id, [id]);
 };
 
 

--- a/src/walker/focus.js
+++ b/src/walker/focus.js
@@ -26,12 +26,60 @@ goog.provide('sre.Focus');
 
 /**
  * @constructor
- * @param {!Array.<Node>} nodes The DOM nodes of the focus.
- * @param {Node} primary The primary component of the focus.
+ * @param {!Array.<!sre.SemanticNode>} nodes The semantic nodes of the focus.
+ * @param {!sre.SemanticNode} primary The primary component of the focus.
  */
 sre.Focus = function(nodes, primary) {
-  this.nodes_ = nodes;
-  this.primary_ = primary;
+
+  /**
+   * @type {!Array.<!sre.SemanticNode>}
+   * @private
+   */
+  this.semanticNodes_ = nodes;
+
+  /**
+   * @type {!sre.SemanticNode}
+   * @private
+   */
+  this.semanticPrimary_ = primary;
+
+  /**
+   * The DOM nodes of the focus.
+   * @type {!Array.<?Node>}
+   * @private
+   */
+  this.domNodes_ = [];
+
+  /**
+   * The primary DOM component of the focus.
+   * @type {Node}
+   * @private
+   */
+  this.domPrimary_ = null;
+
+  /**
+   * The DOM nodes of the focus.
+   * @type {!Array.<?Node>}
+   * @private
+   */
+  this.allNodes_ = [];
+
+};
+
+
+/**
+ * @return {!sre.SemanticNode} The nodes of the focus.
+ */
+sre.Focus.prototype.getSemanticPrimary = function() {
+  return this.semanticPrimary_;
+};
+
+
+/**
+ * @return {!Array.<!sre.SemanticNode>} The nodes of the focus.
+ */
+sre.Focus.prototype.getSemanticNodes = function() {
+  return this.semanticNodes_;
 };
 
 
@@ -39,15 +87,23 @@ sre.Focus = function(nodes, primary) {
  * @return {!Array.<Node>} The nodes of the focus.
  */
 sre.Focus.prototype.getNodes = function() {
-  return this.nodes_;
+  return this.allNodes_;
+};
+
+
+/**
+ * @return {!Array.<?Node>} The nodes of the focus.
+ */
+sre.Focus.prototype.getDomNodes = function() {
+  return this.domNodes_;
 };
 
 
 /**
  * @return {Node} The primary node of the focus. Can be empty.
  */
-sre.Focus.prototype.getPrimary = function() {
-  return this.primary_;
+sre.Focus.prototype.getDomPrimary = function() {
+  return this.domPrimary_;
 };
 
 
@@ -55,7 +111,7 @@ sre.Focus.prototype.getPrimary = function() {
  * @override
  */
 sre.Focus.prototype.toString = function() {
-  return 'Primary:' + this.primary_ + ' Nodes:' + this.nodes_;
+  return 'Primary:' + this.domPrimary_ + ' Nodes:' + this.domNodes_;
 };
 
 
@@ -64,6 +120,65 @@ sre.Focus.prototype.toString = function() {
  * @return {!sre.Focus} The new focus, containing the same component as this.
  */
 sre.Focus.prototype.clone = function() {
-  return new sre.Focus(this.getNodes(), this.getPrimary());
+  var focus = new sre.Focus(this.semanticNodes_, this.semanticPrimary_);
+  focus.domNodes_ = this.domNodes_;
+  focus.domPrimary_ = this.domPrimary_;
+  return focus;
 };
 
+
+/**
+ * Factory method to create focus structures from semantic and DOM nodes.
+ * @param {string} primaryId The semantic id of the primary node.
+ * @param {!Array.<string>} nodeIds The semantic ids of the node list.
+ * @param {!sre.RebuildStree} rebuilt A rebuilt semantic tree structure.
+ * @param {!Node} dom The original DOM node.
+ * @return {!sre.Focus} The new focus.
+ */
+sre.Focus.factory = function(primaryId, nodeIds, rebuilt, dom) {
+  var idFunc = function(id) {return sre.WalkerUtil.getBySemanticId(dom, id);};
+  var dict = rebuilt.nodeDict;
+  var node = idFunc(primaryId);
+  var nodes = nodeIds.map(idFunc);
+  var snodes = nodeIds.map(
+      function(primaryId) {return dict[primaryId];});
+  var focus = new sre.Focus(snodes, dict[primaryId]);
+  focus.domNodes_ = nodes;
+  focus.domPrimary_ = node;
+  focus.allNodes_ = sre.Focus.generateAllVisibleNodes_(
+      nodeIds, nodes, dict, dom);
+  return focus;
+};
+
+
+/**
+ * Generates all existing nodes in the DOM structure corresponding to the
+ * semantic ids.
+ * @param {!Array.<string>} ids The semantic ids.
+ * @param {!Array.<?Node>} nodes The DOM nodes corresponding to the ids, some of
+ *      which might not exist.
+ * @param {!Object.<string, !sre.SemanticNode>} dict A semantic node dictionary.
+ * @param {!Node} domNode The original DOM node.
+ * @return {!Array.<Node>} The list of existing nodes in the DOM tree.
+ * @private
+ */
+sre.Focus.generateAllVisibleNodes_ = function(ids, nodes, dict, domNode) {
+  var idFunc = function(id) {
+      return sre.WalkerUtil.getBySemanticId(domNode, id);
+  };
+  var result = [];
+  for (var i = 0, l = ids.length; i < l; i++) {
+    if (nodes[i]) {
+      result.push(nodes[i]);
+      continue;
+    }
+    var virtual = dict[ids[i]];
+    if (!virtual) continue;
+    var childIds = virtual.childNodes.map(
+        function(x) {return x.id.toString();});
+    var children = childIds.map(idFunc);
+    result = result.concat(
+        sre.Focus.generateAllVisibleNodes_(childIds, children, dict, domNode));
+  }
+  return result;
+};

--- a/src/walker/semantic_walker.js
+++ b/src/walker/semantic_walker.js
@@ -214,7 +214,7 @@ sre.SemanticWalker.prototype.right = function() {
 sre.SemanticWalker.prototype.findFocusOnLevel = function(id) {
   var focus = this.levels.find(
       function(x) {
-        var primary = /** @type {!Node} */(x.getPrimary());
+        var primary = /** @type {!Node} */(x.getDomPrimary());
         var pid = sre.WalkerUtil.getAttribute(
             primary, sre.EnrichMathml.Attribute.ID);
         return pid === id.toString();});

--- a/src/walker/semantic_walker.js
+++ b/src/walker/semantic_walker.js
@@ -214,9 +214,7 @@ sre.SemanticWalker.prototype.right = function() {
 sre.SemanticWalker.prototype.findFocusOnLevel = function(id) {
   var focus = this.levels.find(
       function(x) {
-        var primary = /** @type {!Node} */(x.getDomPrimary());
-        var pid = sre.WalkerUtil.getAttribute(
-            primary, sre.EnrichMathml.Attribute.ID);
-        return pid === id.toString();});
+        var pid = x.getSemanticPrimary().id;
+        return pid === id;});
   return focus;
 };

--- a/src/walker/semantic_walker.js
+++ b/src/walker/semantic_walker.js
@@ -50,36 +50,6 @@ sre.SemanticWalker = function(node, generator, highlighter, xml) {
 goog.inherits(sre.SemanticWalker, sre.AbstractWalker);
 
 
-//TODO: Remove or refactor.
-/**
- * Creates a simple focus for a solitary node.
- * @param {!string} id The node id to focus.
- * @return {!sre.Focus} A focus containing only this node and the other
- *     properties of the old focus.
- * @private
- */
-sre.SemanticWalker.prototype.singletonFocus_ = function(id) {
-  // HERE: Similar to what we have in Syntax walker?
-  var node = this.getBySemanticId(id);
-  return new sre.Focus([node], node);
-};
-
-
-/**
- * Makes a focus for a primary node and a node list, all given by their ids.
- * @param {string} id The semantic id of the primary node.
- * @param {!Array.<string>} ids The semantic id of the node list.
- * @return {!sre.Focus} The new focus.
- * @private
- */
-sre.SemanticWalker.prototype.focusFromId_ = function(id, ids) {
-  var node = this.getBySemanticId(id);
-  var nodes = ids.map(goog.bind(this.getBySemanticId, this));
-  // HERE: Similar to what we have in Syntax walker?
-  return new sre.Focus(nodes, node);
-};
-
-
 /**
  * @override
  */
@@ -127,35 +97,35 @@ sre.SemanticWalker.prototype.combineContentChildren = function(
     case sre.SemanticAttr.Type.MULTIREL:
       return this.makePairList(children, content);
     case sre.SemanticAttr.Type.PREFIXOP:
-      return [this.focusFromId_(children[0], content.concat(children))];
+      return [this.focusFromId(children[0], content.concat(children))];
     case sre.SemanticAttr.Type.POSTFIXOP:
-      return [this.focusFromId_(children[0], children.concat(content))];
+      return [this.focusFromId(children[0], children.concat(content))];
     case sre.SemanticAttr.Type.MATRIX:
     case sre.SemanticAttr.Type.VECTOR:
     case sre.SemanticAttr.Type.FENCED:
-      return [this.focusFromId_(children[0],
+      return [this.focusFromId(children[0],
           [content[0], children[0], content[1]])];
     case sre.SemanticAttr.Type.CASES:
-      return [this.focusFromId_(children[0],
+      return [this.focusFromId(children[0],
           [content[0], children[0]])];
     case sre.SemanticAttr.Type.PUNCTUATED:
       if (role === sre.SemanticAttr.Role.TEXT) {
-        return children.map(goog.bind(this.singletonFocus_, this));
+        return children.map(goog.bind(this.singletonFocus, this));
       }
       //TODO: That needs to be fixed!
       if (children.length === content.length) {
-        return content.map(goog.bind(this.singletonFocus_, this));
+        return content.map(goog.bind(this.singletonFocus, this));
       }
       var focusList = this.combinePunctuations(children, content, [], []);
       return focusList;
     case sre.SemanticAttr.Type.APPL:
-      return [this.focusFromId_(children[0], [children[0], content[0]]),
-        this.singletonFocus_(children[1])];
+      return [this.focusFromId(children[0], [children[0], content[0]]),
+        this.singletonFocus(children[1])];
     case sre.SemanticAttr.Type.ROOT:
-      return [this.singletonFocus_(children[1]),
-              this.singletonFocus_(children[0])];
+      return [this.singletonFocus(children[1]),
+              this.singletonFocus(children[0])];
     default:
-      return children.map(goog.bind(this.singletonFocus_, this));
+      return children.map(goog.bind(this.singletonFocus, this));
   }
 };
 
@@ -186,11 +156,11 @@ sre.SemanticWalker.prototype.combinePunctuations = function(
     prepunct.push(child);
     // Remaining children are all punctuations.
     if (children.length === content.length) {
-      acc.push(this.focusFromId_(child, prepunct.concat(content)));
+      acc.push(this.focusFromId(child, prepunct.concat(content)));
       return acc;
     } else {
       // Recurse
-      acc.push(this.focusFromId_(child, prepunct));
+      acc.push(this.focusFromId(child, prepunct));
       return this.combinePunctuations(children, content, [], acc);
     }
   }
@@ -206,11 +176,11 @@ sre.SemanticWalker.prototype.combinePunctuations = function(
 sre.SemanticWalker.prototype.makePairList = function(children, content) {
   if (children.length === 0) return [];
   if (children.length === 1) {
-    return [this.singletonFocus_(children[0])];
+    return [this.singletonFocus(children[0])];
   }
-  var result = [this.singletonFocus_(children.shift())];
+  var result = [this.singletonFocus(children.shift())];
   for (var i = 0, l = children.length; i < l; i++) {
-    result.push(this.focusFromId_(children[i], [content[i], children[i]]));
+    result.push(this.focusFromId(children[i], [content[i], children[i]]));
   }
   return result;
 };

--- a/src/walker/semantic_walker.js
+++ b/src/walker/semantic_walker.js
@@ -59,14 +59,9 @@ sre.SemanticWalker.prototype.up = function() {
   if (!parent) return null;
   this.levels.pop();
   var found = this.levels.find(
-      function(x) {
-        for (var i = 0, node, nodes = x.getNodes(); node = nodes[i]; i++) {
-          if (sre.WalkerUtil.getAttribute(
-              node, sre.EnrichMathml.Attribute.ID) === parent) {
-            return true;
-          }
-        }
-        return false;
+      function(focus) {
+        return focus.getSemanticNodes().some(
+          function(node) {return node.id.toString() === parent;});
       });
   return found;
 };

--- a/src/walker/syntax_walker.js
+++ b/src/walker/syntax_walker.js
@@ -50,42 +50,6 @@ goog.inherits(sre.SyntaxWalker, sre.AbstractWalker);
 
 
 /**
- * Creates a simple focus for a solitary node.
- * @param {!Node} node The node to focus.
- * @return {!sre.Focus} A focus containing only this node and the other
- *     properties of the old focus.
- * @private
- */
-sre.SyntaxWalker.prototype.singletonFocus_ = function(node) {
-  // HERE: Remains DOM Focus?
-  return new sre.Focus([node], node);
-};
-
-
-/**
- * Makes a singleton focus from an semantic id, if a corresponding node exits.
- * @param {string} id The semantic id.
- * @return {?sre.Focus} The singleton focus for the node.
- * @private
- */
-sre.SyntaxWalker.prototype.focusFromId_ = function(id) {
-  var node = this.getBySemanticId(id);
-  if (node) {
-    return this.singletonFocus_(node);
-  }
-  // var virtual = this.rebuilt.streeRoot.querySelectorAll(
-  //   function(x) {return x.id.toString() === id;})[0];
-  // if (!virtual) {
-  //   return null;
-  // }
-  // var children = virtual.childNodes.map(function(x) {return x.id;});
-  // var nodes = children.map(goog.bind(this.getBySemanticId, this));
-  // return new sre.VirtualFocus(nodes, virtual);
-  return null;
-};
-
-
-/**
  * @override
  */
 sre.SyntaxWalker.prototype.up = function() {
@@ -93,7 +57,7 @@ sre.SyntaxWalker.prototype.up = function() {
   var parent = this.previousLevel();
   if (!parent) return null;
   this.levels.pop();
-  return this.focusFromId_(parent);
+  return this.singletonFocus(parent);
 };
 
 
@@ -106,7 +70,7 @@ sre.SyntaxWalker.prototype.down = function() {
   if (children.length === 0) {
     return null;
   }
-  var focus = this.focusFromId_(children[0]);
+  var focus = this.singletonFocus(children[0]);
   if (focus) {
     this.levels.push(children);
   }
@@ -159,7 +123,7 @@ sre.SyntaxWalker.prototype.left = function() {
   sre.SyntaxWalker.base(this, 'left');
   var index = this.levels.indexOf(this.primaryId()) - 1;
   var id = this.levels.get(index);
-  return id ? this.focusFromId_(id) : null;
+  return id ? this.singletonFocus(id) : null;
 };
 
 
@@ -170,7 +134,7 @@ sre.SyntaxWalker.prototype.right = function() {
   sre.SyntaxWalker.base(this, 'right');
   var index = this.levels.indexOf(this.primaryId()) + 1;
   var id = this.levels.get(index);
-  return id ? this.focusFromId_(id) : null;
+  return id ? this.singletonFocus(id) : null;
 };
 
 
@@ -178,5 +142,5 @@ sre.SyntaxWalker.prototype.right = function() {
  * @override
  */
 sre.SyntaxWalker.prototype.findFocusOnLevel = function(id) {
-  return this.focusFromId_(id.toString());
+  return this.singletonFocus(id.toString());
 };

--- a/src/walker/walker_util.js
+++ b/src/walker/walker_util.js
@@ -80,9 +80,9 @@ sre.WalkerUtil.getSemanticRoot = function(node) {
  * @return {Node} The node for that id.
  */
 sre.WalkerUtil.getBySemanticId = function(root, id) {
-  return (root.querySelector ?
-          root.querySelector(
-      '[' + sre.EnrichMathml.Attribute.ID + '="' + id + '"]') :
-          sre.XpathUtil.evalXPath(
-      './/*[@' + sre.EnrichMathml.Attribute.ID + '="' + id + '"]', root)[0]);
+  if (root.getAttribute(sre.EnrichMathml.Attribute.ID) === id) {
+    return root;
+  }
+  return sre.DomUtil.querySelectorAllByAttrValue(
+    root, sre.EnrichMathml.Attribute.ID, id)[0];
 };


### PR DESCRIPTION
Solves the general problem of MathJax omitting intermediate elements (as described in the SVG case in #21) by  basing walking on re-constructed semantic tree rather than the DOM nodes only. DOM nodes for highlighting are computed as much as possible from existing DOM nodes and semantic tree information.