### PR TITLE
Restore collapse handling

### DIFF
--- a/src/enrich_mathml/case_binomial.js
+++ b/src/enrich_mathml/case_binomial.js
@@ -63,8 +63,12 @@ sre.CaseBinomial.prototype.getMathml = function() {
   if (this.semantic.childNodes.length) {
     var child = this.semantic.childNodes[0];
     this.mml = sre.EnrichMathml.walkTree(/**@type{!sre.SemanticNode}*/(child));
-    sre.EnrichMathml.addCollapsedAttribute(
+    if (this.mml.hasAttribute('data-semantic-type')) {
+      sre.EnrichMathml.addCollapsedAttribute(
         this.mml, [this.semantic.id, child.id]);
+    } else {
+      sre.EnrichMathml.setAttributes(this.mml, this.semantic);
+    }
   }
   return this.mml;
 };

--- a/src/enrich_mathml/case_multiline.js
+++ b/src/enrich_mathml/case_multiline.js
@@ -1,0 +1,61 @@
+// Copyright 2015 Volker Sorge
+//
+// Licensed under the Apache on 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Specialist computations to deal with table elements.
+ *
+ * @author volker.sorge@gmail.com (Volker Sorge)
+ */
+
+goog.provide('sre.CaseMultiline');
+
+goog.require('sre.CaseTable');
+goog.require('sre.DomUtil');
+goog.require('sre.EnrichMathml');
+goog.require('sre.SemanticAttr');
+
+
+
+/**
+ * @constructor
+ * @extends {sre.CaseTable}
+ * @override
+ * @final
+ */
+sre.CaseMultiline = function(semantic) {
+  sre.CaseMultiline.base(this, 'constructor', semantic);
+};
+goog.inherits(sre.CaseMultiline, sre.CaseTable);
+
+
+/**
+ * @override
+ */
+sre.CaseMultiline.test = function(semantic) {
+  return semantic.mathmlTree &&
+    semantic.type === sre.SemanticAttr.Type.MULTILINE;
+};
+
+
+/**
+ * @override
+ */
+sre.CaseMultiline.prototype.getMathml = function() {
+  this.inner = this.semantic.childNodes.map(
+      /**@type{Function}*/(sre.EnrichMathml.walkTree));
+  sre.EnrichMathml.setAttributes(this.mml, this.semantic);
+  // Cleanup in the case some lines where collapsed.
+  this.cleanupCollapsedRows();
+  return this.mml;
+};

--- a/src/enrich_mathml/case_table.js
+++ b/src/enrich_mathml/case_table.js
@@ -94,7 +94,6 @@ sre.CaseTable.prototype.getMathml = function() {
  * Cleanup in case there are collapsed row or line elements.
  */
 sre.CaseTable.prototype.cleanupCollapsedRows = function() {
-  console.log('cleaning up.');
   var children = [];
   var collapse = [this.semantic.id];
   var collapsed = false;

--- a/src/enrich_mathml/case_table.js
+++ b/src/enrich_mathml/case_table.js
@@ -107,7 +107,7 @@ sre.CaseTable.prototype.cleanupCollapsedRows = function() {
       inner.setAttribute(sre.EnrichMathml.Attribute.PARENT, this.semantic.id);
       collapsed = true;
     } else {
-      collapse.push(id);
+      collapse.push(parseInt(id, 10));
     }
   }
   if (collapsed) {

--- a/src/enrich_mathml/case_table.js
+++ b/src/enrich_mathml/case_table.js
@@ -31,7 +31,6 @@ goog.require('sre.SemanticAttr');
  * @constructor
  * @extends {sre.AbstractEnrichCase}
  * @override
- * @final
  */
 sre.CaseTable = function(semantic) {
   sre.CaseTable.base(this, 'constructor', semantic);
@@ -54,6 +53,7 @@ goog.inherits(sre.CaseTable, sre.AbstractEnrichCase);
  * @override
  */
 sre.CaseTable.test = function(semantic) {
+  //DIAGRAM: Multiline here?
   return semantic.mathmlTree &&
       (semantic.type === sre.SemanticAttr.Type.MATRIX ||
       semantic.type === sre.SemanticAttr.Type.VECTOR ||

--- a/src/enrich_mathml/enrich_cases.js
+++ b/src/enrich_mathml/enrich_cases.js
@@ -23,6 +23,7 @@ goog.require('sre.CaseBinomial');
 goog.require('sre.CaseDoubleScript');
 goog.require('sre.CaseEmbellished');
 goog.require('sre.CaseLine');
+goog.require('sre.CaseMultiline');
 goog.require('sre.CaseMultiscripts');
 goog.require('sre.CaseTable');
 goog.require('sre.CaseTensor');
@@ -49,6 +50,8 @@ sre.EnrichCaseFactory.cases.push(
       constr: sre.CaseLine},
     {test: sre.CaseBinomial.test,
       constr: sre.CaseBinomial},
+    {test: sre.CaseMultiline.test,
+     constr: sre.CaseMultiline},
     {test: sre.CaseTable.test,
       constr: sre.CaseTable}
 );

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -137,6 +137,7 @@ sre.SemanticMathml.prototype.rows_ = function(node, children) {
   // Single child node, i.e. the row is meaningless.
   if (children.length === 1) {
     var newNode = this.parse(/** @type {!Element} */(children[0]));
+    // newNode = sre.SemanticProcessor.getInstance().row([newNode]);
   } else {
     // Case of a 'meaningful' row, even if they are empty.
     newNode = sre.SemanticProcessor.getInstance().row(

--- a/src/semantic_tree/semantic_pred.js
+++ b/src/semantic_tree/semantic_pred.js
@@ -312,3 +312,13 @@ sre.SemanticPred.tableIsMultiline = function(table) {
 };
 
 
+/**
+ * Heuristic to decide if a table has a binomial form.
+ * @param {!sre.SemanticNode} table A table node.
+ * @return {boolean} True if it is a binomial form.
+ */
+sre.SemanticPred.isBinomial = function(table) {
+  return table.childNodes.length === 2;
+};
+
+

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -1617,6 +1617,7 @@ sre.SemanticProcessor.rowToLine_ = function(row, opt_role) {
     row.type = sre.SemanticAttr.Type.LINE;
     row.role = role;
     row.childNodes = row.childNodes[0].childNodes;
+    row.childNodes.forEach(function(x) {x.parent = row;});
   }
 };
 

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -1505,8 +1505,20 @@ sre.SemanticProcessor.tableToVector_ = function(node) {
     sre.SemanticProcessor.tableToSquare_(node);
     return;
   }
-  if (vector.childNodes.length === 2) {
-    vector.role = sre.SemanticAttr.Role.BINOMIAL;
+  sre.SemanticProcessor.binomialForm_(vector);
+};
+
+
+/**
+ * Assigns a binomial role if a table consists of two lines only.
+ * @param {!sre.SemanticNode} node The table node.
+ * @private
+ */
+sre.SemanticProcessor.binomialForm_ = function(node) {
+  if (sre.SemanticPred.isBinomial(node)) {
+    node.role = sre.SemanticAttr.Role.BINOMIAL;
+    node.childNodes[0].role = sre.SemanticAttr.Role.BINOMIAL;
+    node.childNodes[1].role = sre.SemanticAttr.Role.BINOMIAL;
   }
 };
 
@@ -1578,6 +1590,9 @@ sre.SemanticProcessor.tableToCases_ = function(table, openFence) {
   }
   table.type = sre.SemanticAttr.Type.CASES;
   table.appendContentNode(openFence);
+  if (sre.SemanticPred.tableIsMultiline(table)) {
+    sre.SemanticProcessor.binomialForm_(table);
+  }
   return table;
 };
 
@@ -1600,6 +1615,7 @@ sre.SemanticProcessor.tableToMultiline = function(table) {
   for (var i = 0, row; row = table.childNodes[i]; i++) {
     sre.SemanticProcessor.rowToLine_(row, sre.SemanticAttr.Role.MULTILINE);
   }
+  sre.SemanticProcessor.binomialForm_(table);
 };
 
 
@@ -1845,8 +1861,12 @@ sre.SemanticProcessor.prototype.fractionLikeNode = function(
         sre.SemanticAttr.Type.LINE, [denom], []);
     var child1 = sre.SemanticProcessor.getInstance().factory_.makeBranchNode(
         sre.SemanticAttr.Type.LINE, [enume], []);
-    return sre.SemanticProcessor.getInstance().factory_.makeBranchNode(
+    var node = sre.SemanticProcessor.getInstance().factory_.makeBranchNode(
         sre.SemanticAttr.Type.MULTILINE, [child0, child1], []);
+    sre.SemanticProcessor.binomialForm_(node);
+    return node;
+    // return sre.SemanticProcessor.getInstance().factory_.makeBranchNode(
+    //     sre.SemanticAttr.Type.MULTILINE, [child0, child1], []);
   } else {
     return sre.SemanticProcessor.getInstance().fractionNode_(denom, enume);
   }

--- a/src/walker/abstract_walker.js
+++ b/src/walker/abstract_walker.js
@@ -445,8 +445,10 @@ sre.AbstractWalker.prototype.rebuildStree_ = function() {
  * @return {?string} The previous level.
  */
 sre.AbstractWalker.prototype.previousLevel = function() {
-  var parent = this.focus_.getSemanticPrimary().parent;
-  return parent ? parent.id.toString() : parent;
+  var dnode = this.focus_.getDomPrimary();
+  return dnode ?
+    sre.WalkerUtil.getAttribute(dnode, sre.EnrichMathml.Attribute.PARENT) :
+    this.focus_.getSemanticPrimary().parent.id.toString();
 };
 
 
@@ -455,10 +457,25 @@ sre.AbstractWalker.prototype.previousLevel = function() {
  * @return {!Array.<T>} The next lower level.
  */
 sre.AbstractWalker.prototype.nextLevel = function() {
+  var dnode = this.focus_.getDomPrimary();
+  if (dnode) {
+    var children = sre.WalkerUtil.splitAttribute(
+      sre.WalkerUtil.getAttribute(dnode, sre.EnrichMathml.Attribute.CHILDREN));
+    var content = sre.WalkerUtil.splitAttribute(
+      sre.WalkerUtil.getAttribute(dnode, sre.EnrichMathml.Attribute.CONTENT));
+    var type = sre.WalkerUtil.getAttribute(
+      dnode, sre.EnrichMathml.Attribute.TYPE);
+    var role = sre.WalkerUtil.getAttribute(
+      dnode, sre.EnrichMathml.Attribute.ROLE);
+    return this.combineContentChildren(
+      /** @type {!sre.SemanticAttr.Type} */ (type),
+      /** @type {!sre.SemanticAttr.Role} */ (role),
+      content, children);
+  }
   var toIds = function(x) { return x.id.toString(); };
   var snode = this.rebuilt.nodeDict[this.primaryId()];
-  var children = snode.childNodes.map(toIds);
-  var content = snode.contentNodes.map(toIds);
+  children = snode.childNodes.map(toIds);
+  content = snode.contentNodes.map(toIds);
   if (children.length === 0) return [];
   return this.combineContentChildren(
       snode.type, snode.role, content, children);

--- a/src/walker/focus.js
+++ b/src/walker/focus.js
@@ -123,6 +123,7 @@ sre.Focus.prototype.clone = function() {
   var focus = new sre.Focus(this.semanticNodes_, this.semanticPrimary_);
   focus.domNodes_ = this.domNodes_;
   focus.domPrimary_ = this.domPrimary_;
+  focus.allNodes_ = this.allNodes_;
   return focus;
 };
 

--- a/src/walker/rebuild_stree.js
+++ b/src/walker/rebuild_stree.js
@@ -246,7 +246,8 @@ sre.RebuildStree.prototype.postProcess = function(snode, collapsed) {
     this.collapsedChildren_(array);
     return snode;
   }
-  if (snode.type === sre.SemanticAttr.Type.VECTOR &&
+  // DIAGRAM: Needs changing for multiline!
+  if (snode.type === sre.SemanticAttr.Type.VECTOR ||
       snode.role === sre.SemanticAttr.Role.BINOMIAL) {
     var children = [];
     for (var i = 1, l = array.length; i < l; i++) {

--- a/tests/enrich_mathml_test.js
+++ b/tests/enrich_mathml_test.js
@@ -10565,7 +10565,143 @@ sre.EnrichMathmlTest.prototype.testMathmlBinomial = function() {
       '</mrow>' +
       '</math>'
   );
-  // Without fences
+};
+
+
+/**
+ * Binomial coefficients generated with fractions and redundant elements.
+ */
+sre.EnrichMathmlTest.prototype.testStreeBinomialWithIgnores = function() {
+  this.brief = false;
+  this.executeMathmlTest(
+    '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mi>k</mi></mfrac></mfenced>',
+    '<math>' +
+      '<mrow type="vector" role="binomial" id="4" children="2,1"' +
+      ' content="5,6" collapsed="(4 2 (3 1))">' +
+      '<mo type="fence" role="open" id="5" parent="4" added="true">(</mo>' +
+      '<mfrac linethickness="0">' +
+      '<mrow type="line" role="binomial" id="2" children="0" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
+      '</mrow>' +
+      '<mi type="identifier" role="latinletter" id="1" parent="4">k</mi>' +
+      '</mfrac>' +
+      '<mo type="fence" role="close" id="6" parent="4" added="true">)</mo>' +
+      '</mrow>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+    '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mpadded><mi>k</mi></mpadded></mfrac></mfenced>',
+    '<math>' +
+      '<mrow type="vector" role="binomial" id="4" children="2,3"' +
+      ' content="5,6">' +
+      '<mo type="fence" role="open" id="5" parent="4" added="true">(</mo>' +
+      '<mfrac linethickness="0">' +
+      '<mrow type="line" role="binomial" id="2" children="0" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
+      '</mrow>' +
+      '<mpadded type="line" role="binomial" id="3" children="1" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">k</mi>' +
+      '</mpadded>' +
+      '</mfrac>' +
+      '<mo type="fence" role="close" id="6" parent="4" added="true">)</mo>' +
+      '</mrow>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mi>n</mi><mpadded><mi>k</mi></mpadded></mfrac></mfenced>',
+    '<math>' +
+      '<mrow type="vector" role="binomial" id="4" children="0,3"' +
+      ' content="5,6" collapsed="(4 (2 0) 3)">' +
+      '<mo type="fence" role="open" id="5" parent="4" added="true">(</mo>' +
+      '<mfrac linethickness="0">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="4">n</mi>' +
+      '<mpadded type="line" role="binomial" id="3" children="1" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">k</mi>' +
+      '</mpadded>' +
+      '</mfrac>' +
+      '<mo type="fence" role="close" id="6" parent="4" added="true">)</mo>' +
+      '</mrow>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mi>k</mi>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>',
+    '<math>' +
+      '<mrow type="vector" role="binomial" id="5" children="3,2"' +
+      ' content="0,6" collapsed="(5 3 (4 2))">' +
+      '<mrow>' +
+      '<mo type="fence" role="open" id="0" parent="5">(</mo>' +
+      '</mrow>' +
+      '<mfrac linethickness="0">' +
+      '<mrow type="line" role="binomial" id="3" children="1" parent="5">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">n</mi>' +
+      '</mrow>' +
+      '<mi type="identifier" role="latinletter" id="2" parent="5">k</mi>' +
+      '</mfrac>' +
+      '<mrow>' +
+      '<mo type="fence" role="close" id="6" parent="5">)</mo>' +
+      '</mrow>' +
+      '</mrow>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mpadded><mi>k</mi></mpadded>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>',
+    '<math>' +
+      '<mrow type="vector" role="binomial" id="5" children="3,4"' +
+      ' content="0,6">' +
+      '<mrow>' +
+      '<mo type="fence" role="open" id="0" parent="5">(</mo>' +
+      '</mrow>' +
+      '<mfrac linethickness="0">' +
+      '<mrow type="line" role="binomial" id="3" children="1" parent="5">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">n</mi>' +
+      '</mrow>' +
+      '<mpadded type="line" role="binomial" id="4" children="2" parent="5">' +
+      '<mi type="identifier" role="latinletter" id="2" parent="4">k</mi>' +
+      '</mpadded>' +
+      '</mfrac>' +
+      '<mrow>' +
+      '<mo type="fence" role="close" id="6" parent="5">)</mo>' +
+      '</mrow>' +
+      '</mrow>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mi>n</mi><mpadded><mi>k</mi></mpadded>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>',
+    '<math>' +
+      '<mrow type="vector" role="binomial" id="5" children="1,4"' +
+      ' content="0,6" collapsed="(5 (3 1) 4)">' +
+      '<mrow>' +
+      '<mo type="fence" role="open" id="0" parent="5">(</mo>' +
+      '</mrow>' +
+      '<mfrac linethickness="0">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="5">n</mi>' +
+      '<mpadded type="line" role="binomial" id="4" children="2" parent="5">' +
+      '<mi type="identifier" role="latinletter" id="2" parent="4">k</mi>' +
+      '</mpadded>' +
+      '</mfrac>' +
+      '<mrow>' +
+      '<mo type="fence" role="close" id="6" parent="5">)</mo>' +
+      '</mrow>' +
+      '</mrow>' +
+      '</math>'
+  );
+};
+
+
+/**
+ * Binomial coefficient like elements, without fences.
+ */
+sre.EnrichMathmlTest.prototype.testStreeBinomialOther = function() {
+  this.brief = false;
   this.executeMathmlTest(
     '<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>',
     '<math>' +
@@ -10573,6 +10709,45 @@ sre.EnrichMathmlTest.prototype.testMathmlBinomial = function() {
       ' id="4" children="0,1" collapsed="(4 (2 0) (3 1))">' +
       '<mi type="identifier" role="latinletter" id="0" parent="4">n</mi>' +
       '<mi type="identifier" role="latinletter" id="1" parent="4">k</mi>' +
+      '</mfrac>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+    '<mfrac linethickness="0"><mrow><mi>n</mi></mrow><mi>k</mi></mfrac>',
+    '<math>' +
+      '<mfrac linethickness="0" type="multiline" role="binomial"' +
+      ' id="4" children="2,1" collapsed="(4 2 (3 1))">' +
+      '<mrow type="line" role="binomial" id="2" children="0" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
+      '</mrow>' +
+      '<mi type="identifier" role="latinletter" id="1" parent="4">k</mi>' +
+      '</mfrac>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+    '<mfrac linethickness="0"><mi>n</mi><mpadded><mi>k</mi></mpadded></mfrac>',
+    '<math>' +
+      '<mfrac linethickness="0" type="multiline" role="binomial"' +
+      ' id="4" children="0,3" collapsed="(4 (2 0) 3)">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="4">n</mi>' +
+      '<mpadded type="line" role="binomial" id="3" children="1" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">k</mi>' +
+      '</mpadded>' +
+      '</mfrac>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+    '<mfrac linethickness="0"><mrow><mi>n</mi></mrow>' +
+      '<mpadded><mi>k</mi></mpadded></mfrac>',
+    '<math>' +
+      '<mfrac linethickness="0" type="multiline" role="binomial"' +
+      ' id="4" children="2,3">' +
+      '<mrow type="line" role="binomial" id="2" children="0" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
+      '</mrow>' +
+      '<mpadded type="line" role="binomial" id="3" children="1" parent="4">' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">k</mi>' +
+      '</mpadded>' +
       '</mfrac>' +
       '</math>'
   );
@@ -10595,3 +10770,4 @@ sre.EnrichMathmlTest.prototype.testMathmlBinomial = function() {
       '</math>'
   );
 };
+

--- a/tests/enrich_mathml_test.js
+++ b/tests/enrich_mathml_test.js
@@ -5706,17 +5706,17 @@ sre.EnrichMathmlTest.prototype.testMathmlVectors = function() {
       '<mtable rowspacing="4pt" columnspacing="1em">' +
       '<mtr type="line" role="vector" id="5" children="3" parent="12">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="3" parent="4">1</mn>' +
+      '<mn type="number" role="integer" id="3" parent="5">1</mn>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="vector" id="8" children="6" parent="12">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="6" parent="7">2</mn>' +
+      '<mn type="number" role="integer" id="6" parent="8">2</mn>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="vector" id="11" children="9" parent="12">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="9" parent="10">3</mn>' +
+      '<mn type="number" role="integer" id="9" parent="11">3</mn>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
@@ -5736,17 +5736,17 @@ sre.EnrichMathmlTest.prototype.testMathmlVectors = function() {
       '<mtable rowspacing="4pt" columnspacing="1em">' +
       '<mtr type="line" role="vector" id="3" children="1" parent="10">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="1" parent="2">1</mn>' +
+      '<mn type="number" role="integer" id="1" parent="3">1</mn>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="vector" id="6" children="4" parent="10">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="4" parent="5">2</mn>' +
+      '<mn type="number" role="integer" id="4" parent="6">2</mn>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="vector" id="9" children="7" parent="10">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="7" parent="8">3</mn>' +
+      '<mn type="number" role="integer" id="7" parent="9">3</mn>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
@@ -5764,12 +5764,12 @@ sre.EnrichMathmlTest.prototype.testMathmlVectors = function() {
       '<mtable>' +
       '<mtr type="line" role="binomial" id="2" children="0" parent="6">' +
       '<mtd>' +
-      '<mi type="identifier" role="latinletter" id="0" parent="1">n</mi>' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="binomial" id="5" children="3" parent="6">' +
       '<mtd>' +
-      '<mi type="identifier" role="latinletter" id="3" parent="4">k</mi>' +
+      '<mi type="identifier" role="latinletter" id="3" parent="5">k</mi>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
@@ -5788,7 +5788,7 @@ sre.EnrichMathmlTest.prototype.testMathmlVectors = function() {
       '<mtable>' +
       '<mtr type="line" role="determinant" id="2" children="0" parent="3">' +
       '<mtd>' +
-      '<mi type="identifier" role="latinletter" id="0" parent="1">n</mi>' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
@@ -5807,7 +5807,7 @@ sre.EnrichMathmlTest.prototype.testMathmlVectors = function() {
       '<mtable>' +
       '<mtr type="line" role="squarematrix" id="2" children="0" parent="3">' +
       '<mtd>' +
-      '<mi type="identifier" role="latinletter" id="0" parent="1">n</mi>' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">n</mi>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
@@ -5977,14 +5977,14 @@ sre.EnrichMathmlTest.prototype.testMathmlTables = function() {
       '<math>' +
       '<mrow type="punctuated" role="sequence" id="19"' +
       ' children="13,14,15,16,17,18" content="14,16,18">' +
-      '<mrow type="cases" role="unknown" id="13" children="6,12"' +
+      '<mrow type="cases" role="binomial" id="13" children="6,12"' +
       ' content="0" parent="19">' +
       '<mo type="punctuation" role="openfence" id="0" parent="13">{</mo>' +
       '<mtable>' +
-      '<mtr type="line" role="cases" id="6" children="4" parent="13">' +
+      '<mtr type="line" role="binomial" id="6" children="4" parent="13">' +
       '<mtd>' +
       '<mrow type="punctuated" role="sequence" id="4" children="1,2,3"' +
-      ' content="2" parent="5">' +
+      ' content="2" parent="6">' +
       '<mi type="identifier" role="latinletter" id="1" parent="4">a</mi>' +
       '<mo type="punctuation" role="comma" id="2" parent="4"' +
       ' operator="punctuated">,</mo>' +
@@ -5992,10 +5992,10 @@ sre.EnrichMathmlTest.prototype.testMathmlTables = function() {
       '</mrow>' +
       '</mtd>' +
       '</mtr>' +
-      '<mtr type="line" role="cases" id="12" children="10" parent="13">' +
+      '<mtr type="line" role="binomial" id="12" children="10" parent="13">' +
       '<mtd>' +
       '<mrow type="punctuated" role="sequence" id="10" children="7,8,9"' +
-      ' content="8" parent="11">' +
+      ' content="8" parent="12">' +
       '<mi type="identifier" role="latinletter" id="7" parent="10">b</mi>' +
       '<mo type="punctuation" role="comma" id="8" parent="10"' +
       ' operator="punctuated">,</mo>' +
@@ -6027,7 +6027,7 @@ sre.EnrichMathmlTest.prototype.testMathmlTables = function() {
       '<mtr type="line" role="multiline" id="5" children="3" parent="21">' +
       '<mtd>' +
       '<mrow type="relseq" role="equality" id="3" children="0,2"' +
-      ' content="1" parent="4">' +
+      ' content="1" parent="5">' +
       '<mi type="identifier" role="latinletter" id="0" parent="3">x</mi>' +
       '<maligngroup/>' +
       '<mo type="relation" role="equality" id="1" parent="3"' +
@@ -6039,7 +6039,7 @@ sre.EnrichMathmlTest.prototype.testMathmlTables = function() {
       '<mtr type="line" role="multiline" id="11" children="9" parent="21">' +
       '<mtd>' +
       '<mrow type="relseq" role="equality" id="9" children="6,8"' +
-      ' content="7" parent="10">' +
+      ' content="7" parent="11">' +
       '<mi type="identifier" role="latinletter" id="6" parent="9">y</mi>' +
       '<maligngroup/>' +
       '<mo type="relation" role="equality" id="7" parent="9"' +
@@ -6051,7 +6051,7 @@ sre.EnrichMathmlTest.prototype.testMathmlTables = function() {
       '<mtr type="line" role="multiline" id="20" children="18" parent="21">' +
       '<mtd>' +
       '<mrow type="relseq" role="equality" id="18" children="17,15"' +
-      ' content="14" parent="19">' +
+      ' content="14" parent="20">' +
       '<mrow type="infixop" role="implicit" id="17" children="12,13"' +
       ' content="16" parent="18">' +
       '<mi type="identifier" role="latinletter" id="12" parent="17">x</mi>' +
@@ -6192,17 +6192,17 @@ sre.EnrichMathmlTest.prototype.testMathmlMatricesWithIgnores = function() {
       '<mtable rowspacing="4pt" columnspacing="1em">' +
       '<mtr type="line" role="vector" id="5" children="3" parent="12">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="3" parent="4">1</mn>' +
+      '<mn type="number" role="integer" id="3" parent="5">1</mn>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="vector" id="8" children="6" parent="12">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="6" parent="7">2</mn>' +
+      '<mn type="number" role="integer" id="6" parent="8">2</mn>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="vector" id="11" children="9" parent="12">' +
       '<mtd>' +
-      '<mn type="number" role="integer" id="9" parent="10">3</mn>' +
+      '<mn type="number" role="integer" id="9" parent="11">3</mn>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
@@ -6273,7 +6273,7 @@ sre.EnrichMathmlTest.prototype.testMathmlMatricesWithIgnores = function() {
       '<mtr type="line" role="cases" id="8" children="6" parent="24">' +
       '<mtd>' +
       '<mrow type="relseq" role="equality" id="6" children="3,5"' +
-      ' content="4" parent="7">' +
+      ' content="4" parent="8">' +
       '<mi type="identifier" role="latinletter" id="3" parent="6">x</mi>' +
       '<maligngroup/>' +
       '<mo type="relation" role="equality" id="4" parent="6"' +
@@ -6285,7 +6285,7 @@ sre.EnrichMathmlTest.prototype.testMathmlMatricesWithIgnores = function() {
       '<mtr type="line" role="cases" id="14" children="12" parent="24">' +
       '<mtd>' +
       '<mrow type="relseq" role="equality" id="12" children="9,11"' +
-      ' content="10" parent="13">' +
+      ' content="10" parent="14">' +
       '<mi type="identifier" role="latinletter" id="9" parent="12">y</mi>' +
       '<maligngroup/>' +
       '<mo type="relation" role="equality" id="10" parent="12"' +
@@ -6297,7 +6297,7 @@ sre.EnrichMathmlTest.prototype.testMathmlMatricesWithIgnores = function() {
       '<mtr type="line" role="cases" id="23" children="21" parent="24">' +
       '<mtd>' +
       '<mrow type="relseq" role="equality" id="21" children="20,18"' +
-      ' content="17" parent="22">' +
+      ' content="17" parent="23">' +
       '<mrow type="infixop" role="implicit" id="20" children="15,16"' +
       ' content="19" parent="21">' +
       '<mi type="identifier" role="latinletter" id="15" parent="20">x</mi>' +
@@ -10552,17 +10552,46 @@ sre.EnrichMathmlTest.prototype.testMathmlBinomial = function() {
       '<mtable>' +
       '<mtr type="line" role="binomial" id="3" children="1" parent="7">' +
       '<mtd>' +
-      '<mi type="identifier" role="latinletter" id="1" parent="2">a</mi>' +
+      '<mi type="identifier" role="latinletter" id="1" parent="3">a</mi>' +
       '</mtd>' +
       '</mtr>' +
       '<mtr type="line" role="binomial" id="6" children="4" parent="7">' +
       '<mtd>' +
-      '<mi type="identifier" role="latinletter" id="4" parent="5">b</mi>' +
+      '<mi type="identifier" role="latinletter" id="4" parent="6">b</mi>' +
       '</mtd>' +
       '</mtr>' +
       '</mtable>' +
       '<mo type="fence" role="close" id="8" parent="7">)</mo>' +
       '</mrow>' +
+      '</math>'
+  );
+  // Without fences
+  this.executeMathmlTest(
+    '<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>',
+    '<math>' +
+      '<mfrac linethickness="0" type="multiline" role="binomial"' +
+      ' id="4" children="0,1" collapsed="(4 (2 0) (3 1))">' +
+      '<mi type="identifier" role="latinletter" id="0" parent="4">n</mi>' +
+      '<mi type="identifier" role="latinletter" id="1" parent="4">k</mi>' +
+      '</mfrac>' +
+      '</math>'
+  );
+  this.executeMathmlTest(
+    '<mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd>' +
+      '<mi>b</mi></mtd></mtr></mtable>',
+    '<math>' +
+      '<mtable type="multiline" role="binomial" id="6" children="2,5">' +
+      '<mtr type="line" role="binomial" id="2" children="0" parent="6">' +
+      '<mtd>' +
+      '<mi type="identifier" role="latinletter" id="0" parent="2">a</mi>' +
+      '</mtd>' +
+      '</mtr>' +
+      '<mtr type="line" role="binomial" id="5" children="3" parent="6">' +
+      '<mtd>' +
+      '<mi type="identifier" role="latinletter" id="3" parent="5">b</mi>' +
+      '</mtd>' +
+      '</mtr>' +
+      '</mtable>' +
       '</math>'
   );
 };

--- a/tests/rebuild_stree_test.js
+++ b/tests/rebuild_stree_test.js
@@ -2116,9 +2116,50 @@ sre.RebuildStreeTest.prototype.testRebuildBinomial = function() {
   this.executeRebuildTest(
     '<mrow><mo>(</mo><mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd>' +
       '<mi>b</mi></mtd></mtr></mtable><mo>)</mo></mrow>');
-  // Without fences
+};
+
+
+/**
+ * Binomial coefficients generated with fractions and redundant elements.
+ */
+sre.RebuildStreeTest.prototype.testRebuildBinomialWithIgnores = function() {
+  this.executeRebuildTest(
+    '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mi>k</mi></mfrac></mfenced>');
+  this.executeRebuildTest(
+    '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mpadded><mi>k</mi></mpadded></mfrac></mfenced>');
+  this.executeRebuildTest(
+      '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mi>n</mi><mpadded><mi>k</mi></mpadded></mfrac></mfenced>');
+  this.executeRebuildTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mi>k</mi>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>');
+  this.executeRebuildTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mpadded><mi>k</mi></mpadded>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>');
+  this.executeRebuildTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mi>n</mi><mpadded><mi>k</mi></mpadded>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>');
+};
+
+
+/**
+ * Binomial coefficient like elements, without fences.
+ */
+sre.RebuildStreeTest.prototype.testRebuildBinomialOther = function() {
   this.executeRebuildTest(
     '<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>');
+  this.executeRebuildTest(
+    '<mfrac linethickness="0"><mrow><mi>n</mi></mrow><mi>k</mi></mfrac>');
+  this.executeRebuildTest(
+    '<mfrac linethickness="0"><mi>n</mi><mpadded><mi>k</mi></mpadded></mfrac>');
+  this.executeRebuildTest(
+    '<mfrac linethickness="0"><mrow><mi>n</mi></mrow>' +
+      '<mpadded><mi>k</mi></mpadded></mfrac>');
   this.executeRebuildTest(
     '<mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd>' +
       '<mi>b</mi></mtd></mtr></mtable>');

--- a/tests/rebuild_stree_test.js
+++ b/tests/rebuild_stree_test.js
@@ -2116,5 +2116,11 @@ sre.RebuildStreeTest.prototype.testRebuildBinomial = function() {
   this.executeRebuildTest(
     '<mrow><mo>(</mo><mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd>' +
       '<mi>b</mi></mtd></mtr></mtable><mo>)</mo></mrow>');
+  // Without fences
+  this.executeRebuildTest(
+    '<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>');
+  this.executeRebuildTest(
+    '<mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd>' +
+      '<mi>b</mi></mtd></mtr></mtable>');
 };
 

--- a/tests/semantic_tree_test.js
+++ b/tests/semantic_tree_test.js
@@ -6414,6 +6414,7 @@ sre.SemanticTreeTest.prototype.testStreeTables = function() {
       '</table>');
 };
 
+// Missing: MatricesWithIgnores
 
 /**
  * Limit functions.
@@ -10498,9 +10499,205 @@ sre.SemanticTreeTest.prototype.testStreeBinomial = function() {
       '</line>' +
       '</children>' +
       '</vector>');
-  // Without fences
+};
+
+
+/**
+ * Binomial coefficients generated with fractions and redundant elements.
+ */
+sre.SemanticTreeTest.prototype.testStreeBinomialWithIgnores = function() {
+  this.brief = false;
+  this.executeTreeTest(
+      '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mi>k</mi></mfrac></mfenced>',
+      '<vector role="binomial" id="4">' +
+      '<content>' +
+      '<fence role="open" id="5">(</fence>' +
+      '<fence role="close" id="6">)</fence>' +
+      '</content>' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</vector>');
+  this.executeTreeTest(
+      '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mpadded><mi>k</mi></mpadded></mfrac></mfenced>',
+      '<vector role="binomial" id="4">' +
+      '<content>' +
+      '<fence role="open" id="5">(</fence>' +
+      '<fence role="close" id="6">)</fence>' +
+      '</content>' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</vector>');
+  this.executeTreeTest(
+      '<mfenced open="(" close=")"><mfrac linethickness="0">' +
+      '<mi>n</mi><mpadded><mi>k</mi></mpadded></mfrac></mfenced>',
+      '<vector role="binomial" id="4">' +
+      '<content>' +
+      '<fence role="open" id="5">(</fence>' +
+      '<fence role="close" id="6">)</fence>' +
+      '</content>' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</vector>');
+  this.executeTreeTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mi>k</mi>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>',
+      '<vector role="binomial" id="5">' +
+      '<content>' +
+      '<fence role="open" id="0">(</fence>' +
+      '<fence role="close" id="6">)</fence>' +
+      '</content>' +
+      '<children>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="4">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="2">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</vector>');
+  this.executeTreeTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mrow><mi>n</mi></mrow><mpadded><mi>k</mi></mpadded>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>',
+      '<vector role="binomial" id="5">' +
+      '<content>' +
+      '<fence role="open" id="0">(</fence>' +
+      '<fence role="close" id="6">)</fence>' +
+      '</content>' +
+      '<children>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="4">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="2">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</vector>');
+  this.executeTreeTest(
+      '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0">' +
+      '<mi>n</mi><mpadded><mi>k</mi></mpadded>' +
+      '</mfrac><mrow><mo>)</mo></mrow></mrow>',
+      '<vector role="binomial" id="5">' +
+      '<content>' +
+      '<fence role="open" id="0">(</fence>' +
+      '<fence role="close" id="6">)</fence>' +
+      '</content>' +
+      '<children>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="4">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="2">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</vector>');
+};
+
+
+/**
+ * Binomial coefficient like elements, without fences.
+ */
+sre.SemanticTreeTest.prototype.testStreeBinomialOther = function() {
+  this.brief = false;
   this.executeTreeTest(
     '<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>',
+      '<multiline role="binomial" id="4">' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</multiline>'
+  );
+  this.executeTreeTest(
+    '<mfrac linethickness="0"><mrow><mi>n</mi></mrow><mi>k</mi></mfrac>',
+      '<multiline role="binomial" id="4">' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</multiline>'
+  );
+  this.executeTreeTest(
+    '<mfrac linethickness="0"><mi>n</mi><mpadded><mi>k</mi></mpadded></mfrac>',
+      '<multiline role="binomial" id="4">' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</multiline>'
+  );
+  this.executeTreeTest(
+    '<mfrac linethickness="0"><mrow><mi>n</mi></mrow>' +
+      '<mpadded><mi>k</mi></mpadded></mfrac>',
       '<multiline role="binomial" id="4">' +
       '<children>' +
       '<line role="binomial" id="2">' +

--- a/tests/semantic_tree_test.js
+++ b/tests/semantic_tree_test.js
@@ -6238,12 +6238,12 @@ sre.SemanticTreeTest.prototype.testStreeTables = function() {
       '<punctuation role="fullstop" id="18">.</punctuation>' +
       '</content>' +
       '<children>' +
-      '<cases role="unknown" id="13">' +
+      '<cases role="binomial" id="13">' +
       '<content>' +
       '<punctuation role="openfence" id="0">{</punctuation>' +
       '</content>' +
       '<children>' +
-      '<line role="cases" id="6">' +
+      '<line role="binomial" id="6">' +
       '<children>' +
       '<punctuated role="sequence" id="4">' +
       '<content>' +
@@ -6257,7 +6257,7 @@ sre.SemanticTreeTest.prototype.testStreeTables = function() {
       '</punctuated>' +
       '</children>' +
       '</line>' +
-      '<line role="cases" id="12">' +
+      '<line role="binomial" id="12">' +
       '<children>' +
       '<punctuated role="sequence" id="10">' +
       '<content>' +
@@ -10498,5 +10498,41 @@ sre.SemanticTreeTest.prototype.testStreeBinomial = function() {
       '</line>' +
       '</children>' +
       '</vector>');
+  // Without fences
+  this.executeTreeTest(
+    '<mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>',
+      '<multiline role="binomial" id="4">' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">n</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="3">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="1">k</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</multiline>'
+  );
+  this.executeTreeTest(
+    '<mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd>' +
+      '<mi>b</mi></mtd></mtr></mtable>',
+    '<multiline role="binomial" id="6">' +
+      '<children>' +
+      '<line role="binomial" id="2">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="0">a</identifier>' +
+      '</children>' +
+      '</line>' +
+      '<line role="binomial" id="5">' +
+      '<children>' +
+      '<identifier role="latinletter" font="italic" id="3">b</identifier>' +
+      '</children>' +
+      '</line>' +
+      '</children>' +
+      '</multiline>'
+  );
 };
 

--- a/tmp/branches
+++ b/tmp/branches
@@ -1,0 +1,25 @@
+master
+develop
+general_cleanup
+simplify_setup
+speech-css
+
+
+(exp ((average-pitch . "2") (pitch-range . "2"))
+     "StartFraction"
+     (((pitch-range . "3")) "x")
+     "Over"
+     (((pitch-range . "1")) "y")
+     "EndFraction"
+     )
+
+master
+develop
+diagram_project
+- robust_walking
+-- restore_collapse_handling
+--- binomial_multiline
+emacspeak_project
+integrate_skeleton (probably can be dropped)
+moss_project
+

--- a/tmp/issues.js
+++ b/tmp/issues.js
@@ -1,0 +1,104 @@
+// Tables
+// Binomial:
+var mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mrow class="MJX-TeXAtom-OPEN"><mo maxsize="2.047em" minsize="2.047em">(</mo></mrow><mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac><mrow class="MJX-TeXAtom-CLOSE"><mo maxsize="2.047em" minsize="2.047em">)</mo></mrow></mrow></math>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+console.log(enr.toString());
+var stree = sre.Semantic.getTreeFromString(mml);
+console.log(sre.DomUtil.formatXml(enr.toString()));
+console.log(sre.DomUtil.formatXml(stree.toString()));
+
+var mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mrow class="MJX-TeXAtom-OPEN"><mo maxsize="2.047em" minsize="2.047em">(</mo></mrow><mfrac linethickness="0"><mi>n</mi><mrow><mi>k</mi><mo>+</mo><mi>l</mi></mrow></mfrac><mrow class="MJX-TeXAtom-CLOSE"><mo maxsize="2.047em" minsize="2.047em">)</mo></mrow></mrow></math>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+console.log(enr.toString());
+var stree = sre.Semantic.getTreeFromString(mml);
+console.log(sre.DomUtil.formatXml(enr.toString()));
+console.log(sre.DomUtil.formatXml(stree.toString()));
+
+
+var mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mo>(</mo><mtable rowspacing="4pt" columnspacing="1em"><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+console.log(enr.toString());
+var stree = sre.Semantic.getTreeFromString(mml);
+console.log(sre.DomUtil.formatXml(enr.toString()));
+console.log(sre.DomUtil.formatXml(stree.toString()));
+
+var mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mfenced open="(" close=")"><mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac></mfenced></math>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+console.log(enr.toString());
+var stree = sre.Semantic.getTreeFromString(mml);
+console.log(sre.DomUtil.formatXml(enr.toString()));
+console.log(sre.DomUtil.formatXml(stree.toString()));
+
+var mml = '<mrow><mrow><mo>(</mo></mrow><mfrac linethickness="0"><mrow><mi>n</mi><mo>+</mo><mi>k</mi><mo>+</mo><mi>l</mi></mrow><mrow><mi>k</mi><mo>+</mo><mi>l</mi><mo>-</mo><mn>1</mn></mrow></mfrac><mrow><mo>)</mo></mrow></mrow>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+console.log(enr.toString());
+
+
+// Lines:
+var mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mtable rowspacing="4pt" columnspacing="1em"><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd></mtr></mtable></math>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+var stree = sre.Semantic.getTreeFromString(mml);
+console.log(sre.DomUtil.formatXml(enr.toString()));
+console.log(sre.DomUtil.formatXml(stree.toString()));
+
+
+
+// Embellished stuff
+
+var stree = sre.Semantic.getTreeFromString('<math><mo>(</mo><mi>x</mi><msup><mo>+</mo><mn>2</mn></msup><mi>y</mi><msub><mo>)</mo><mn>2</mn></msub></math>');
+
+console.log(sre.DomUtil.formatXml(sre.Semantic.getTreeFromString('<math><mo>(</mo><mi>x</mi><msup><mo>)</mo><mn>2</mn></msup></math>').toString()));
+
+
+var mml = '<math><mmultiscripts><mi>A</mi><mn>3</mn><mn>4</mn><mi>k</mi><mi>l</mi>' +
+    '<mprescripts/><mn>1</mn><mn>2</mn><mi>i</mi><mi>j</mi></mmultiscripts></math>';
+var enr = sre.Enrich.semanticMathmlSync(mml);
+var stree = sre.Semantic.getTreeFromString(mml);
+var reb = new sre.RebuildStree(enr);
+console.log(sre.DomUtil.formatXml(enr.toString()));
+console.log(sre.DomUtil.formatXml(stree.toString()));
+console.log(sre.DomUtil.formatXml(reb.stree.toString()));
+
+var mml = '<math><mmultiscripts><mi>X</mi><none/><mi>i</mi><none/><mi>j</mi>' +
+    '<mprescripts/><none/></mmultiscripts></math>';
+
+
+var mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mi>x</mi><mo>=</mo><mfrac><mrow><mo>&#x2212;</mo><mi>b</mi><mo>&#xB1;</mo><msqrt><mrow><msup><mi>b</mi><mn>2</mn></msup><mo>&#x2212;</mo><mn>4</mn><mi>a</mi><mi>c</mi></mrow></msqrt></mrow><mrow><mn>2</mn><mi>a</mi></mrow></mfrac></mrow></math>';
+
+var skel = sre.SemanticSkeleton.fromTree(stree.root);
+
+
+var mjx = '<span class="MathJax" id="MathJax-Element-2-Frame" tabindex="0" role="application" aria-label="StartBinomialOrMatrix n Choose k EndBinomialOrMatrix" haslabel="true" hasspeech="true" style="text-align: center;"><nobr><span class="math" id="MathJax-Span-15" data-semantic-complexity="10.2" style="width: 2.324em; display: inline-block;"><span style="display: inline-block; position: relative; width: 2.205em; height: 0px; font-size: 105%;"><span style="position: absolute; clip: rect(2.443em 1002.03em 5.241em -999.997em); top: -4.104em; left: 0em;"><span class="mrow" id="MathJax-Span-16"><span class="mrow" id="MathJax-Span-17" data-semantic-type="vector" data-semantic-role="binomial" data-semantic-id="5" data-semantic-children="1,2" data-semantic-content="0,6" data-semantic-collapsed="(5 (3 1) (4 2))" data-semantic-complexity="10.2" data-semantic-speech="StartBinomialOrMatrix n Choose k EndBinomialOrMatrix"><span class="texatom" id="MathJax-Span-18" data-semantic-complexity="1"><span class="mrow" id="MathJax-Span-19"><span class="mo" id="MathJax-Span-20" data-semantic-type="fence" data-semantic-role="open" data-semantic-id="0" data-semantic-parent="5" data-semantic-complexity="1" data-semantic-speech="left-parenthesis" style="vertical-align: -0.592em;"><span style="font-family: STIXSizeThreeSym;">(</span></span></span></span><span class="mfrac" id="MathJax-Span-21" data-semantic-complexity="5.2"><span style="display: inline-block; position: relative; width: 0.479em; height: 0px; margin-right: 0.122em; margin-left: 0.122em;"><span style="position: absolute; clip: rect(3.396em 1000.48em 4.17em -999.997em); top: -4.64em; left: 50%; margin-left: -0.235em;"><span class="mi" id="MathJax-Span-22" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-id="1" data-semantic-parent="3" data-semantic-complexity="1" data-semantic-speech="n" style="font-family: STIXGeneral; font-style: italic;">n</span><span style="display: inline-block; width: 0px; height: 3.991em;"></span></span><span style="position: absolute; clip: rect(3.158em 1000.48em 4.17em -999.997em); top: -3.271em; left: 50%; margin-left: -0.235em;"><span class="mi" id="MathJax-Span-23" data-semantic-type="identifier" data-semantic-role="latinletter" data-semantic-font="italic" data-semantic-id="2" data-semantic-parent="4" data-semantic-complexity="1" data-semantic-speech="k" style="font-family: STIXGeneral; font-style: italic;">k<span style="display: inline-block; overflow: hidden; height: 1px; width: 0.003em;"></span></span><span style="display: inline-block; width: 0px; height: 3.991em;"></span></span></span></span><span class="texatom" id="MathJax-Span-24" data-semantic-complexity="1"><span class="mrow" id="MathJax-Span-25"><span class="mo" id="MathJax-Span-26" data-semantic-type="fence" data-semantic-role="close" data-semantic-id="6" data-semantic-parent="5" data-semantic-complexity="1" data-semantic-speech="right-parenthesis" style="vertical-align: -0.592em;"><span style="font-family: STIXSizeThreeSym;">)</span></span></span></span></span></span><span style="display: inline-block; width: 0px; height: 4.11em;"></span></span></span><span style="display: inline-block; overflow: hidden; vertical-align: -1.059em; border-left: 0px solid; width: 0px; height: 2.691em;"></span></span></nobr></span>';
+
+console.log(sre.DomUtil.formatXml(sre.EnrichMathml.removeAttributePrefix(mjx.toString())));
+
+var mml = '<math><mi>a</mi></math>';
+
+
+  // var virtual = this.rebuilt.streeRoot.querySelectorAll(
+  //   function(x) {return x.id.toString() === id;})[0];
+  // if (!virtual) {
+  //   return null;
+  // }
+  // var children = virtual.childNodes.map(function(x) {return x.id;});
+  // var nodes = children.map(goog.bind(this.getBySemanticId, this));
+  // return new sre.VirtualFocus(nodes, virtual);
+
+
+
+// <math><munderover><mi>a</mi><mi>b</mi><mi>c</mi></munderover></math>
+// x^2_2
+
+
+// {n \choose k}
+// \begin{pmatrix}a\\b\end{pmatrix}
+// {{n + 1}\choose k}
+// \begin{pmatrix}a+1\\b\end{pmatrix}
+
+
+mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mo>(</mo><mtable rowspacing="4pt" columnspacing="1em"><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>';
+
+mml = '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mrow><mo>(</mo><mtable rowspacing="4pt" columnspacing="1em"><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>';
+
+
+mml = '<math><mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac></math>';


### PR DESCRIPTION
Handles all walking issues related to [a11y 161](https://github.com/mathjax/MathJax-a11y/issues/161)
Still some UX discrepancy for 
* binomial from fraction vs from table
* binomial from fraction if padding elements (mrow, mpadded etc.) are available of not
* prefix announcements for elements in cases/multilines.