### PR TITLE
Grammatic structure

### DIFF
--- a/doc/moss-project.org
+++ b/doc/moss-project.org
@@ -166,3 +166,34 @@
 
 *** Depth and balancing might be interesting.
     We could effectively invert order of dynamic and static constraints. Not sure if that makes any sense.
+
+* Grammar structure
+
+** General idea
+
+*** Grammar elements are added and removed via personality annotations.
+
+*** Keywords are mapped to either a string or a boolean.
+
+*** XML element gets special grammar attribute with space separated list of keywords and strings, or boolean.
+
+*** This way we can check in the rules if a grammatical case is applicable.
+
+**** This only works for the next level. Needs to be repeated, if necessary.
+
+**** Alternative, always propagate the grammar attribute.
+
+*** Should work both for [n] and [m] nodes.
+
+** To subsume preprocess, correction, remove, sre_flag, font/hiddenfont, annotation:unit
+
+** Singleton structure similar to global parameters
+
+*** Holds mappings of grammar keywords to either strings or booleans.
+
+*** Equipped with mappings to correction functions for certain grammar keywords.
+
+** Dispatch in extra grammar keyword in personality annotations.
+
+*** Test with determinant simple and hidden fonts.
+

--- a/doc/moss-project.org
+++ b/doc/moss-project.org
@@ -197,3 +197,21 @@
 
 *** Test with determinant simple and hidden fonts.
 
+*** New grammar syntax in personality annotations:
+
+**** grammar:aa:bb="something":cc=@font:dd=CSFsomething:!ee
+     Note the overall separator is : as not to conflict with separators between
+     personality annotations.
+
+***** Adds boolean aa
+
+***** Adds bb with value something
+
+***** Adds cc with font name of the current node
+
+***** Adds dd with string computed by CSFsomething
+
+***** Removes ee 
+
+*** We might want to have special function for grammar checking instead of the grammar attribute
+    Check after integration with the Trie (WP1.3)

--- a/doc/moss-project.org
+++ b/doc/moss-project.org
@@ -176,16 +176,17 @@
 *** Keywords are mapped to either a string or a boolean.
 
 *** XML element gets special grammar attribute with space separated list of keywords and strings, or boolean.
-
+    
 *** This way we can check in the rules if a grammatical case is applicable.
 
 **** This only works for the next level. Needs to be repeated, if necessary.
-
+     
 **** Alternative, always propagate the grammar attribute.
 
 *** Should work both for [n] and [m] nodes.
 
 ** To subsume preprocess, correction, remove, sre_flag, font/hiddenfont, annotation:unit
+   Got rid of font, sre_flag, remove.
 
 ** Singleton structure similar to global parameters
 

--- a/src/common/auditory_description.js
+++ b/src/common/auditory_description.js
@@ -202,7 +202,9 @@ sre.AuditoryDescription.toSimpleString_ = function(descrs, separator) {
  */
 sre.AuditoryDescription.preprocessString_ = function(text) {
   // TODO (sorge) Find a proper treatment of single numbers.
-  // (MOSS) Do with grammar annotation for numbers in mathspeak. 
+  // 
+  // (MOSS) Do with grammar annotation for numbers in mathspeak or possibly in
+  // the actual evaluation unit, when all WPs are combined.
   var engine = sre.Engine.getInstance();
   if (engine.domain == 'mathspeak' && text.match(/^\d{1}$/)) {
     return text;

--- a/src/common/auditory_description.js
+++ b/src/common/auditory_description.js
@@ -221,17 +221,14 @@ sre.AuditoryDescription.preprocessString_ = function(text) {
  * @private
  */
 sre.AuditoryDescription.preprocessDescription_ = function(descr) {
-  if (descr.annotation) {
-    descr.text += ':' + descr.annotation;
-    descr.annotation = '';
-  }
+  descr.text = sre.Grammar.getInstance().runPreprocessors(
+    descr.correction, descr.text);
   if (descr.preprocess) {
-    descr.text = sre.Grammar.getInstance().processCorrections(
-      descr.correction,
-        sre.AuditoryDescription.preprocessString_(descr.text)
-    );
+    descr.text = sre.AuditoryDescription.preprocessString_(descr.text);
     descr.preprocess = false;
   }
+  descr.text = sre.Grammar.getInstance().runCorrections(
+    descr.correction, descr.text);
 };
 
 

--- a/src/common/auditory_description.js
+++ b/src/common/auditory_description.js
@@ -202,29 +202,13 @@ sre.AuditoryDescription.toSimpleString_ = function(descrs, separator) {
  */
 sre.AuditoryDescription.preprocessString_ = function(text) {
   // TODO (sorge) Find a proper treatment of single numbers.
+  // (MOSS) Do with grammar annotation for numbers in mathspeak. 
   var engine = sre.Engine.getInstance();
   if (engine.domain == 'mathspeak' && text.match(/^\d{1}$/)) {
     return text;
   }
   var result = engine.evaluator(text, engine.dynamicCstr);
   return result || text;
-};
-
-
-/**
- * Applies a corrective string to the given description text.
- * @param {string} text The original description text.
- * @param {string} correction The correction string to be applied.
- * @return {string} The cleaned up string.
- * @private
- */
-sre.AuditoryDescription.processCorrections_ = function(text, correction) {
-  if (!correction || !text) {
-    return text;
-  }
-  var correctionComp = correction.split(/ |-/);
-  var regExp = new RegExp('^' + correctionComp.join('( |-)') + '( |-)');
-  return text.replace(regExp, '');
 };
 
 
@@ -240,9 +224,10 @@ sre.AuditoryDescription.preprocessDescription_ = function(descr) {
     descr.annotation = '';
   }
   if (descr.preprocess) {
-    descr.text = sre.AuditoryDescription.processCorrections_(
-        sre.AuditoryDescription.preprocessString_(descr.text),
-        descr.correction);
+    descr.text = sre.Grammar.getInstance().processCorrections(
+      descr.correction,
+        sre.AuditoryDescription.preprocessString_(descr.text)
+    );
     descr.preprocess = false;
   }
 };

--- a/src/common/auditory_description.js
+++ b/src/common/auditory_description.js
@@ -202,7 +202,7 @@ sre.AuditoryDescription.toSimpleString_ = function(descrs, separator) {
  */
 sre.AuditoryDescription.preprocessString_ = function(text) {
   // TODO (sorge) Find a proper treatment of single numbers.
-  // 
+  //
   // (MOSS) Do with grammar annotation for numbers in mathspeak or possibly in
   // the actual evaluation unit, when all WPs are combined.
   var engine = sre.Engine.getInstance();
@@ -222,13 +222,13 @@ sre.AuditoryDescription.preprocessString_ = function(text) {
  */
 sre.AuditoryDescription.preprocessDescription_ = function(descr) {
   descr.text = sre.Grammar.getInstance().runPreprocessors(
-    descr.correction, descr.text);
+      descr.correction, descr.text);
   if (descr.preprocess) {
     descr.text = sre.AuditoryDescription.preprocessString_(descr.text);
     descr.preprocess = false;
   }
   descr.text = sre.Grammar.getInstance().runCorrections(
-    descr.correction, descr.text);
+      descr.correction, descr.text);
 };
 
 

--- a/src/rule_engine/dynamic_cstr.js
+++ b/src/rule_engine/dynamic_cstr.js
@@ -124,16 +124,17 @@ sre.DynamicCstr.prototype.equal = function(cstr) {
 /**
  * Convenience method to create a standard dynamic constraint, that follows a
  * pre-prescribed order of the axes.
- * @param {...string} cstrs Dynamic constraint values for the Axes.
+ * @param {...string} var_args Dynamic constraint values for the Axes.
  * @return {!sre.DynamicCstr}
  */
-sre.DynamicCstr.create = function(cstrs) {
-  var axes = [sre.Engine.Axis.DOMAIN,
-              sre.Engine.Axis.STYLE,
-              sre.Engine.Axis.LANGUAGE,
-              sre.Engine.Axis.TOPIC,
-              sre.Engine.Axis.MODALITY
-             ];
+sre.DynamicCstr.create = function(var_args) {
+  var axes = [
+    sre.Engine.Axis.DOMAIN,
+    sre.Engine.Axis.STYLE,
+    sre.Engine.Axis.LANGUAGE,
+    sre.Engine.Axis.TOPIC,
+    sre.Engine.Axis.MODALITY
+  ];
   var dynamicCstr = {};
   var cstrList = Array.prototype.slice.call(arguments, 0);
   for (var i = 0, l = cstrList.length, k = axes.length; i < l && i < k; i++) {

--- a/src/rule_engine/grammar.js
+++ b/src/rule_engine/grammar.js
@@ -78,22 +78,13 @@ sre.Grammar.prototype.clear = function() {
  * @param {string} parameter The parameter name.
  * @param {boolean|string} value The parameter's value.
  * @return {boolean|string} The old value if it existed.
+ * @private
  */
-sre.Grammar.prototype.setParameter = function(parameter, value) {
+sre.Grammar.prototype.setParameter_ = function(parameter, value) {
   var oldValue = this.parameters_[parameter];
   value ? this.parameters_[parameter] = value :
     delete this.parameters_[parameter];
   return oldValue;
-};
-
-
-/**
- * Returns a grammar parameter if it exists.
- * @param {string} parameter The parameter name.
- * @return {boolean|string} The parameter's value.
- */
-sre.Grammar.prototype.getParameter = function(parameter) {
-  return this.parameters_[parameter];
 };
 
 
@@ -147,7 +138,7 @@ sre.Grammar.prototype.getState = function() {
  */
 sre.Grammar.prototype.pushState = function(assignment) {
   for (var key in assignment) {
-    assignment[key] = this.setParameter(key, assignment[key]);
+    assignment[key] = this.setParameter_(key, assignment[key]);
   };
   this.stateStack_.push(assignment);
 };
@@ -159,39 +150,15 @@ sre.Grammar.prototype.pushState = function(assignment) {
 sre.Grammar.prototype.popState = function() {
   var assignment = this.stateStack_.pop();
   for (var key in assignment) {
-    this.setParameter(key, assignment[key]);
+    this.setParameter_(key, assignment[key]);
   }
 };
 
 
 /**
- * Adds grammatical annotations to an XML node.
+ * Adds the grammatical state as attributed to an XML node.
  * @param {Node} node Adds a grammar value to the node.
- * @param {string} annotation The grammatical annotation.
- * @param {string|boolean} value The annotation value.
  */
-sre.Grammar.prototype.addGrammar = function(node, annotation, value) {
-  var grammar = node.getAttribute(sre.Grammar.ATTRIBUTE) || '';
-  var attr = typeof value === 'string' ? annotation + ':' + value : annotation;
-  if (!grammar.match(RegExp(' ' + attr))) {
-    node.setAttribute(sre.Grammar.ATTRIBUTE, grammar + ' ' + attr);
-  }
-};
-
-
-sre.Grammar.prototype.removeGrammar = function(node, annotation, value) {
-  var grammar = node.getAttribute(sre.Grammar.ATTRIBUTE) || '';
-  var attr = typeof value === 'string' ? annotation + ':' + value : annotation;
-  var match = grammar.match(RegExp(' ' + attr));
-  if (match) {
-    grammar = grammar.slice(0, match.index) +
-      grammar.slice(match.index + attr.length + 1);
-    grammar ? node.setAttribute(sre.Grammar.ATTRIBUTE, grammar) :
-      node.removeAttribute(sre.Grammar.ATTRIBUTE);
-  }
-};
-
-
 sre.Grammar.prototype.setAttribute = function(node) {
   if (node && node.nodeType === sre.DomUtil.NodeType.ELEMENT_NODE) {
     var state = this.getState();
@@ -265,6 +232,14 @@ sre.Grammar.correctFont_ = function(text, correction) {
   return text.replace(regExp, '');
 };
 
+
+/**
+ * Attaches an annotation to a description.
+ * @param {string} text The original description text.
+ * @param {string} annotation The annotation string to be applied.
+ * @return {string} The cleaned up string.
+ * @private
+ */
 sre.Grammar.addAnnotation_ = function(text, annotation) {
   return text + ':' + annotation;
 };

--- a/src/rule_engine/grammar.js
+++ b/src/rule_engine/grammar.js
@@ -51,9 +51,10 @@ sre.Grammar = function() {
 
   /**
    * @type {Array.<Object.<string, string|boolean>>}
+   * @private
    */
   this.stateStack_ = [];
-  
+
 };
 goog.addSingletonGetter(sre.Grammar);
 
@@ -83,7 +84,7 @@ sre.Grammar.prototype.clear = function() {
 sre.Grammar.prototype.setParameter_ = function(parameter, value) {
   var oldValue = this.parameters_[parameter];
   value ? this.parameters_[parameter] = value :
-    delete this.parameters_[parameter];
+      delete this.parameters_[parameter];
   return oldValue;
 };
 
@@ -139,7 +140,7 @@ sre.Grammar.prototype.getState = function() {
 sre.Grammar.prototype.pushState = function(assignment) {
   for (var key in assignment) {
     assignment[key] = this.setParameter_(key, assignment[key]);
-  };
+  }
   this.stateStack_.push(assignment);
 };
 
@@ -163,7 +164,7 @@ sre.Grammar.prototype.setAttribute = function(node) {
   if (node && node.nodeType === sre.DomUtil.NodeType.ELEMENT_NODE) {
     var state = this.getState();
     if (state) {
-      node.setAttribute(sre.Grammar.ATTRIBUTE, state); 
+      node.setAttribute(sre.Grammar.ATTRIBUTE, state);
     }
   }
 };
@@ -197,6 +198,7 @@ sre.Grammar.prototype.runPreprocessors = function(state, text) {
  * @param {string} text The original description text.
  * @param {Object.<string, Function>} funcs Dictionary of processor functions.
  * @return {string} The grammatically corrected string.
+ * @private
  */
 sre.Grammar.prototype.runProcessors_ = function(state, text, funcs) {
   var corrections = state.split(' ');
@@ -245,5 +247,7 @@ sre.Grammar.addAnnotation_ = function(text, annotation) {
 };
 
 
-sre.Grammar.getInstance().setCorrection('ignoreFont', sre.Grammar.correctFont_);
-sre.Grammar.getInstance().setPreprocessor('annotation', sre.Grammar.addAnnotation_);
+sre.Grammar.getInstance().setCorrection('ignoreFont',
+                                        sre.Grammar.correctFont_);
+sre.Grammar.getInstance().setPreprocessor('annotation',
+                                          sre.Grammar.addAnnotation_);

--- a/src/rule_engine/grammar.js
+++ b/src/rule_engine/grammar.js
@@ -1,0 +1,64 @@
+// Copyright 2016 Volker Sorge
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Supported by MOSS grant.
+
+/**
+ * @fileoverview A data structure to maintain grammatical context.
+ * @author volker.sorge@gmail.com (Volker Sorge)
+ */
+
+goog.provide('sre.Grammar');
+
+
+
+/**
+ * @constructor
+ */
+sre.Grammar = function() {
+
+  /**
+   * Object holding global parameters that can be set by the stores.
+   * @type {Object.<string, string>}
+   * @private
+   */
+  this.parameters_ = {};
+
+
+  
+  
+};
+goog.addSingletonGetter(sre.Grammar);
+
+
+/**
+ * Sets a grammar parameter.
+ * @param {string} parameter The parameter name.
+ * @param {string} value The parameter's value.
+ */
+sre.Grammar.prototype.setParameter = function(parameter, value) {
+  this.parameters_[parameter] = value;
+};
+
+
+/**
+ * Returns a grammar parameter if it exists.
+ * @param {string} parameter The parameter name.
+ * @return {string} The parameter's value.
+ */
+sre.Grammar.prototype.getParameter = function(parameter) {
+  return this.parameters_[parameter];
+};
+
+

--- a/src/rule_engine/grammar.js
+++ b/src/rule_engine/grammar.js
@@ -225,7 +225,4 @@ sre.Grammar.correctFont_ = function(text, correction) {
   return text.replace(regExp, '');
 };
 
-sre.Grammar.getInstance().setCorrection('remove', sre.Grammar.correctFont_);
-
-
-
+sre.Grammar.getInstance().setCorrection('ignoreFont', sre.Grammar.correctFont_);

--- a/src/rule_engine/grammar.js
+++ b/src/rule_engine/grammar.js
@@ -29,36 +29,161 @@ goog.provide('sre.Grammar');
 sre.Grammar = function() {
 
   /**
-   * Object holding global parameters that can be set by the stores.
-   * @type {Object.<string, string>}
+   * Grammatical annotations that need to be propagated.
+   * @type {Object.<string, string|boolean>}
    * @private
    */
   this.parameters_ = {};
 
-
-  
+  /**
+   * Maps grammatical annotations to correction functions.
+   * @type {Object.<string, Function>}
+   * @private
+   */
+  this.corrections_ = {};
   
 };
 goog.addSingletonGetter(sre.Grammar);
 
 
 /**
+ * @type {string}
+ */
+sre.Grammar.ATTRIBUTE = 'grammar';
+
+
+/**
+ * Clears the grammar object.
+ */
+sre.Grammar.prototype.clear = function() {
+  this.parameters_ = {};
+};
+
+
+/**
  * Sets a grammar parameter.
  * @param {string} parameter The parameter name.
- * @param {string} value The parameter's value.
+ * @param {boolean|string} value The parameter's value.
  */
 sre.Grammar.prototype.setParameter = function(parameter, value) {
-  this.parameters_[parameter] = value;
+  value ? this.parameters_[parameter] = value :
+    delete this.parameters_[parameter];
 };
 
 
 /**
  * Returns a grammar parameter if it exists.
  * @param {string} parameter The parameter name.
- * @return {string} The parameter's value.
+ * @return {boolean|string} The parameter's value.
  */
 sre.Grammar.prototype.getParameter = function(parameter) {
   return this.parameters_[parameter];
 };
+
+
+/**
+ * Sets a grammar correction.
+ * @param {string} correction The correction name.
+ * @param {Function} func The correction function.
+ */
+sre.Grammar.prototype.setCorrection = function(correction, func) {
+  this.corrections_[correction] = func;
+};
+
+
+/**
+ * Returns a grammar correction function if it exists.
+ * @param {string} correction The grammar annotation.
+ * @return {Function} The correction function.
+ */
+sre.Grammar.prototype.getCorrection = function(correction) {
+  return this.corrections_[correction];
+};
+
+
+/**
+ * @return {!string} A string version of the grammatical state.
+ */
+sre.Grammar.prototype.getState = function() {
+  var pairs = [];
+  for (var key in this.parameters_) {
+    var value = this.parameters_[key];
+    pairs.push(typeof value === 'string' ? key + ':' + value : key);
+  }
+  return pairs.join(' ');
+};
+
+
+/**
+ * Adds grammatical annotations to an XML node.
+ * @param {Node} node Adds a grammar value to the node.
+ * @param {string} annotation The grammatical annotation.
+ * @param {string|boolean} value The annotation value.
+ */
+sre.Grammar.prototype.addGrammar = function(node, annotation, value) {
+  var grammar = node.getAttribute(sre.Grammar.ATTRIBUTE) || '';
+  var attr = typeof value === 'string' ? annotation + ':' + value : annotation;
+  if (!grammar.match(RegExp(' ' + attr))) {
+    node.setAttribute(sre.Grammar.ATTRIBUTE, grammar + ' ' + attr);
+  }
+};
+
+
+sre.Grammar.prototype.removeGrammar = function(node, annotation, value) {
+  var grammar = node.getAttribute(sre.Grammar.ATTRIBUTE) || '';
+  var attr = typeof value === 'string' ? annotation + ':' + value : annotation;
+  var match = grammar.match(RegExp(' ' + attr));
+  if (match) {
+    grammar = grammar.slice(0, match.index) +
+      grammar.slice(match.index + attr.length + 1);
+    grammar ? node.setAttribute(sre.Grammar.ATTRIBUTE, grammar) :
+      node.removeAttribute(sre.Grammar.ATTRIBUTE);
+  }
+};
+
+
+
+/**
+ * Applies a grammatical corrections to a given description text.
+ * @param {string} state The saved state of the grammar.
+ * @param {string} text The original description text.
+ * @return {string} The grammatically corrected string.
+ */
+sre.Grammar.prototype.processCorrections = function(state, text) {
+  var corrections = state.split(' ');
+  for (var i = 0, l = corrections.length; i < l; i++) {
+    var corr = corrections[i].split(':');
+    var key = corr[0];
+    var func = this.getCorrection(key);
+    if (!func) {
+      continue;
+    }
+    var value = corr[1];
+    text = value ? func(text, value) : func(text);
+  }
+  return text;
+};
+
+
+// The following is temporary!
+//
+/**
+ * Applies a corrective string to the given description text.
+ * @param {string} text The original description text.
+ * @param {string} correction The correction string to be applied.
+ * @return {string} The cleaned up string.
+ * @private
+ */
+sre.Grammar.processCorrections_ = function(text, correction) {
+  if (!correction || !text) {
+    return text;
+  }
+  var correctionComp = correction.split(/ |-/);
+  var regExp = new RegExp('^' + correctionComp.join('( |-)') + '( |-)');
+  return text.replace(regExp, '');
+};
+
+sre.Grammar.getInstance().setCorrection('remove', sre.Grammar.processCorrections_);
+
 
 

--- a/src/rule_engine/math_simple_store.js
+++ b/src/rule_engine/math_simple_store.js
@@ -87,11 +87,11 @@ sre.MathSimpleStore.prototype.lookupRule = function(node, dynamic) {
             // TODO (MOSS): Remove after Trie introduction.
             // rule.precondition.constraints[0].slice(0,-1).slice(16);
           },
-        this));
+          this));
   return rules.length ?
-    rules.sort(function(r1, r2) {
-      return sre.Engine.getInstance().comparator.
-        compare(r1.dynamicCstr, r2.dynamicCstr);})[0] : null;
+      rules.sort(function(r1, r2) {
+        return sre.Engine.getInstance().comparator.
+           compare(r1.dynamicCstr, r2.dynamicCstr);})[0] : null;
 };
 
 

--- a/src/rule_engine/math_store.js
+++ b/src/rule_engine/math_store.js
@@ -266,8 +266,6 @@ sre.MathStore.prototype.evaluate_ = function(text) {
       {
         'text': text,
         'preprocess': true,
-        'correction':
-            sre.Grammar.getInstance().getParameter('remove') ||
-            ''
+        'correction': sre.Grammar.getInstance().getState()
       });
 };

--- a/src/rule_engine/math_store.js
+++ b/src/rule_engine/math_store.js
@@ -267,7 +267,7 @@ sre.MathStore.prototype.evaluate_ = function(text) {
         'text': text,
         'preprocess': true,
         'correction':
-            sre.SpeechRuleEngine.getInstance().getGlobalParameter('remove') ||
+            sre.Grammar.getInstance().getParameter('remove') ||
             ''
       });
 };

--- a/src/rule_engine/speech_rule.js
+++ b/src/rule_engine/speech_rule.js
@@ -205,6 +205,7 @@ sre.SpeechRule.Component.prototype.addAttribute = function(attr) {
     this[attr.trim()] = 'true';
   } else {
     this[attr.substring(0, colon).trim()] = attr.slice(colon + 1).trim();
+    // TODO (MOSS) Here we need to handle grammar attributes.
   }
 };
 

--- a/src/rule_engine/speech_rule_engine.js
+++ b/src/rule_engine/speech_rule_engine.js
@@ -56,13 +56,6 @@ sre.SpeechRuleEngine = function() {
   this.activeStore_ = null;
 
   /**
-   * Object holding global parameters that can be set by the stores.
-   * @type {Object.<string, string>}
-   * @private
-   */
-  this.globalParameters_ = {};
-
-  /**
    * Caches speech strings by node id.
    * @type {Object.<string, !Array.<sre.AuditoryDescription>>}
    * @private
@@ -70,29 +63,6 @@ sre.SpeechRuleEngine = function() {
   this.cache_ = {};
 };
 goog.addSingletonGetter(sre.SpeechRuleEngine);
-
-
-/**
- * Sets a global parameter in the speech rule engine's store.
- * @param {string} parameter The parameter name.
- * @param {string} value The parameter's value.
- */
-sre.SpeechRuleEngine.prototype.setGlobalParameter = function(parameter, value) {
-  this.globalParameters_[parameter] = value;
-};
-
-
-//TODO: (MOSS) WP 1.4
-// Extend to Context structure
-//
-/**
- * Returns the a global parameter if it exists.
- * @param {string} parameter The parameter name.
- * @return {string} The parameter's value.
- */
-sre.SpeechRuleEngine.prototype.getGlobalParameter = function(parameter) {
-  return this.globalParameters_[parameter];
-};
 
 
 /**

--- a/src/rule_engine/speech_rule_engine.js
+++ b/src/rule_engine/speech_rule_engine.js
@@ -290,7 +290,9 @@ sre.SpeechRuleEngine.prototype.evaluateTree_ = function(node) {
       case sre.SpeechRule.Type.TEXT:
         selected = this.constructString(node, content);
         if (selected) {
-          descrs = [new sre.AuditoryDescription({text: selected})];
+          descrs = [new sre.AuditoryDescription(
+            {text: selected,
+             correction: sre.Grammar.getInstance().getState()})];
         }
         break;
       case sre.SpeechRule.Type.PERSONALITY:

--- a/src/rule_engine/speech_rule_engine.js
+++ b/src/rule_engine/speech_rule_engine.js
@@ -291,8 +291,8 @@ sre.SpeechRuleEngine.prototype.evaluateTree_ = function(node) {
         selected = this.constructString(node, content);
         if (selected) {
           descrs = [new sre.AuditoryDescription(
-            {text: selected,
-             correction: sre.Grammar.getInstance().getState()})];
+              {text: selected,
+                correction: sre.Grammar.getInstance().getState()})];
         }
         break;
       case sre.SpeechRule.Type.PERSONALITY:
@@ -536,10 +536,12 @@ sre.SpeechRuleEngine.prototype.updateEngine = function() {
 };
 
 
+//TODO: This string processing should be moved into a refactored rule components
+//      module.
 /**
- * 
- * @param {!Node} node
- * @param {string} grammar
+ * Processes the grammar annotations of a rule.
+ * @param {!Node} node The node to which the rule is applied.
+ * @param {string} grammar The grammar annotations.
  */
 sre.SpeechRuleEngine.prototype.processGrammar = function(node, grammar) {
   var components = grammar.split(':');

--- a/src/speech_rules/mathml_store_rules.js
+++ b/src/speech_rules/mathml_store_rules.js
@@ -147,7 +147,7 @@ sre.MathmlStoreRules.initDefaultRules_ = function() {
       '[t] "string" (pitch:0.5, rate:0.5); [t] text()');
 
   defineRule('unit', 'default.default',
-      '[t] text() (annotation:unit, preprocess)',
+      '[t] text() (grammar:annotation="unit", preprocess)',
       'self::mathml:mi', '@class="MathML-Unit"');
 
   // Script elements.

--- a/src/speech_rules/mathml_store_util.js
+++ b/src/speech_rules/mathml_store_util.js
@@ -165,39 +165,3 @@ sre.MathmlStoreUtil.contentIterator = function(nodes, context) {
     return contextDescr.concat(descrs);
   };
 };
-
-
-/**
- * Rewrites a font attribute in a node to hide it during application of
- *    subsequent rules.
- * @param {!Node} node The node to be modified.
- * @return {Array.<Node>} The node list containing the modified node only.
- */
-sre.MathmlStoreUtil.hideFont = function(node) {
-  if (node.hasAttribute('font')) {
-    var value = node.getAttribute('font');
-    node.removeAttribute('font');
-    sre.Grammar.getInstance().setParameter('remove', value);
-    node.setAttribute('hiddenfont', value);
-  }
-  return [node];
-};
-
-
-/**
- * Rewrites a hidden font attribute in a node to be visible again as a regular
- *     font attribute. This is implemented as a custom string function.
- * @param {!Node} node The node to be modified.
- * @return {!string} The empty string.
- */
-sre.MathmlStoreUtil.showFont = function(node) {
-  if (node.hasAttribute('hiddenfont')) {
-    var value = node.getAttribute('hiddenfont');
-    node.removeAttribute('hiddenfont');
-    sre.Grammar.getInstance().setParameter('remove', '');
-    node.setAttribute('font', value);
-  }
-  return '';
-};
-
-

--- a/src/speech_rules/mathml_store_util.js
+++ b/src/speech_rules/mathml_store_util.js
@@ -22,6 +22,7 @@ goog.provide('sre.MathmlStoreUtil');
 
 goog.require('sre.AuditoryDescription');
 goog.require('sre.Engine');
+goog.require('sre.Grammar');
 goog.require('sre.MathUtil');
 goog.require('sre.XpathUtil');
 
@@ -176,7 +177,7 @@ sre.MathmlStoreUtil.hideFont = function(node) {
   if (node.hasAttribute('font')) {
     var value = node.getAttribute('font');
     node.removeAttribute('font');
-    sre.SpeechRuleEngine.getInstance().setGlobalParameter('remove', value);
+    sre.Grammar.getInstance().setParameter('remove', value);
     node.setAttribute('hiddenfont', value);
   }
   return [node];
@@ -193,7 +194,7 @@ sre.MathmlStoreUtil.showFont = function(node) {
   if (node.hasAttribute('hiddenfont')) {
     var value = node.getAttribute('hiddenfont');
     node.removeAttribute('hiddenfont');
-    sre.SpeechRuleEngine.getInstance().setGlobalParameter('remove', '');
+    sre.Grammar.getInstance().setParameter('remove', '');
     node.setAttribute('font', value);
   }
   return '';

--- a/src/speech_rules/mathspeak_rules.js
+++ b/src/speech_rules/mathspeak_rules.js
@@ -132,10 +132,6 @@ sre.MathspeakRules.initCustomFunctions_ = function() {
   addCSF('CSFunderscript', sre.MathspeakUtil.nestedUnderscore);
   addCSF('CSFoverscript', sre.MathspeakUtil.nestedOverscore);
 
-  // Font related.
-  addCQF('CQFhideFont', sre.MathmlStoreUtil.hideFont);
-  addCSF('CSFshowFont', sre.MathmlStoreUtil.showFont);
-
   addCTXF('CTXFordinalCounter', sre.MathspeakUtil.ordinalCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
 
@@ -172,14 +168,16 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
   // Font rules
   defineRule(
       'font', 'mathspeak.default',
-      '[t] @font; [n] CQFhideFont; [t] CSFshowFont',
-      'self::*', '@font', '@font!="normal"');
+      '[t] @font; [n] self::* (grammar:ignoreFont=@font)',
+      'self::*', '@font', 'not(contains(@grammar, "ignoreFont"))',
+      '@font!="normal"');
 
   defineRule(
       'font-identifier-short', 'mathspeak.default',
-      '[t] @font; [n] CQFhideFont; [t] CSFshowFont',
+      '[t] @font; [n] self::* (grammar:ignoreFont=@font)',
       'self::identifier', 'string-length(text())=1',
-      '@font', '@font="normal"', '""=translate(text(), ' +
+      '@font', 'not(contains(@grammar, "ignoreFont"))', '@font="normal"',
+      '""=translate(text(), ' +
       '"abcdefghijklmnopqrstuvwxyz\u03B1\u03B2\u03B3\u03B4' +
       '\u03B5\u03B6\u03B7\u03B8\u03B9\u03BA\u03BB\u03BC\u03BD\u03BE\u03BF' +
       '\u03C0\u03C1\u03C2\u03C3\u03C4\u03C5\u03C6\u03C7\u03C8\u03C9' +
@@ -190,24 +188,28 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
 
   defineRule(
       'font-identifier', 'mathspeak.default',
-      '[t] @font; [n] CQFhideFont; [t] CSFshowFont',
+      '[t] @font; [n] self::* (grammar:ignoreFont=@font)',
       'self::identifier', 'string-length(text())=1',
-      '@font', '@font="normal"', '@role!="unit"');
+      '@font', '@font="normal"', 'not(contains(@grammar, "ignoreFont"))',
+      '@role!="unit"');
 
   defineRule(
       'omit-font', 'mathspeak.default',
-      '[n] CQFhideFont; [t] CSFshowFont',
-      'self::identifier', 'string-length(text())=1', '@font', '@font="italic"');
+      '[n] self::* (grammar:ignoreFont=@font)',
+      'self::identifier', 'string-length(text())=1', '@font',
+      'not(contains(@grammar, "ignoreFont"))', '@font="italic"');
 
   defineRule(
       'german-font', 'mathspeak.default',
-      '[t] "German"; [n] CQFhideFont; [t] CSFshowFont',
-      'self::*', '@font', '@font="fraktur"');
+      '[t] "German"; [n] self::* (grammar:ignoreFont=@font)',
+      'self::*', '@font', 'not(contains(@grammar, "ignoreFont"))',
+      '@font="fraktur"');
 
   defineRule(
       'german-font', 'mathspeak.default',
-      '[t] "bold German"; [n] CQFhideFont; [t] CSFshowFont',
-      'self::*', '@font', '@font="bold-fraktur"');
+      '[t] "bold German"; [n] self::* (grammar:ignoreFont=@font)',
+      'self::*', '@font', 'not(contains(@grammar, "ignoreFont"))',
+      '@font="bold-fraktur"');
 
   // Number rules
   defineRule(
@@ -249,7 +251,7 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
   defineRule(
       'number-baseline', 'mathspeak.default',
       '[t] "Baseline"; [n] text()',
-      'self::number', 'not(@hiddenfont)',
+      'self::number', 'not(contains(@grammar, "ignoreFont"))',
       'preceding-sibling::identifier',
       'preceding-sibling::*[1][@role="latinletter" or @role="greekletter" or' +
       ' @role="otherletter"]',
@@ -263,9 +265,9 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
 
   defineRule(
       'number-baseline-font', 'mathspeak.default',
-      '[t] "Baseline"; [t] @font; [n] CQFhideFont; [t] CSFshowFont',
-      'self::number', '@font', '@font!="normal"',
-      'preceding-sibling::identifier',
+      '[t] "Baseline"; [t] @font; [n] self::* (grammar:ignoreFont=@font)',
+      'self::number', '@font', 'not(contains(@grammar, "ignoreFont"))',
+      '@font!="normal"', 'preceding-sibling::identifier',
       'preceding-sibling::*[@role="latinletter" or @role="greekletter" or' +
       ' @role="otherletter"]',
       'parent::*/parent::infixop[@role="implicit"]');
@@ -279,7 +281,8 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
   defineRule(
       'identifier', 'mathspeak.default', '[m] CQFspaceoutIdentifier',
       'self::identifier', 'string-length(text())>1', '@role!="unit"',
-      '@role!="protected"', 'not(@font) or @font="normal" or @hiddenfont');
+      '@role!="protected"',
+      'not(@font) or @font="normal" or contains(@grammar, "ignoreFont")');
 
   defineRule(
       'identifier', 'mathspeak.default', '[n] text()',

--- a/src/speech_rules/mathspeak_rules.js
+++ b/src/speech_rules/mathspeak_rules.js
@@ -141,8 +141,6 @@ sre.MathspeakRules.initCustomFunctions_ = function() {
 
   // Layout related.
   addCQF('CQFdetIsSimple', sre.MathspeakUtil.determinantIsSimple);
-  addCSF('CSFdetMarkSimple', sre.MathspeakUtil.determinantMarkSimple);
-  addCSF('CSFdetUnMarkSimple', sre.MathspeakUtil.determinantUnMarkSimple);
 };
 
 
@@ -1028,23 +1026,21 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
 
   defineRule(
       'determinant-simple', 'mathspeak.default',
-      '[t] CSFdetMarkSimple;' +
       '[t] "Start"; [t] count(children/*);  [t] "By";' +
       '[t] count(children/*[1]/children/*); [t] "Determinant";' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"Row");' +
-      ' [t] "EndDeterminant"; [t] CSFdetUnMarkSimple',
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"Row",' +
+      'grammar:simpleDet); [t] "EndDeterminant"',
       'self::matrix', '@role="determinant"', 'CQFdetIsSimple');
   defineSpecialisedRule(
       'determinant-simple', 'mathspeak.default', 'mathspeak.sbrief',
-      '[t] CSFdetMarkSimple;' +
       '[t] count(children/*);  [t] "By";' +
       '[t] count(children/*[1]/children/*); [t] "Determinant";' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"Row");' +
-      ' [t] "EndDeterminant"; [t] CSFdetUnMarkSimple');
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"Row",' +
+      'grammar:simpleDet); [t] "EndDeterminant"');
   defineRule(
       'row-simple', 'mathspeak.default',
       '[m] children/*;',
-      'self::row', '@role="determinant"', '@sre_flag="simple"');
+      'self::row', '@role="determinant"', 'contains(@grammar, "simpleDet")');
 
   defineRule(
       'layout', 'mathspeak.default', '[t] "StartLayout"; ' +

--- a/src/speech_rules/mathspeak_rules.js
+++ b/src/speech_rules/mathspeak_rules.js
@@ -1170,7 +1170,7 @@ sre.MathspeakRules.initMathspeakRules_ = function() {
   // Unit rules.
   defineRule(
       'unit', 'mathspeak.default',
-      '[t] text() (annotation:unit, preprocess)',
+      '[t] text() (grammar:annotation="unit", preprocess)',
       'self::identifier', '@role="unit"');
   defineRule(
       'unit-square', 'mathspeak.default',

--- a/src/speech_rules/mathspeak_util.js
+++ b/src/speech_rules/mathspeak_util.js
@@ -889,30 +889,6 @@ sre.MathspeakUtil.determinantIsSimple = function(node) {
 
 
 /**
- * String function to mark elements of a determinant as simple.
- * @param {!Node} node The determinant node.
- * @return {string} The empty string.
- */
-sre.MathspeakUtil.determinantMarkSimple = function(node) {
-  var rows = sre.XpathUtil.evalXPath('children/row', node);
-  rows.forEach(function(row) {row.setAttribute('sre_flag', 'simple');});
-  return '';
-};
-
-
-/**
- * String function to unmark elements of a determinant.
- * @param {!Node} node The determinant node.
- * @return {string} The empty string.
- */
-sre.MathspeakUtil.determinantUnMarkSimple = function(node) {
-  var rows = sre.XpathUtil.evalXPath('children/row', node);
-  rows.forEach(function(row) {row.removeAttribute('sre_flag');});
-  return '';
-};
-
-
-/**
  * Generate constraints for the specialised baseline rules of relation
  * sequences.
  * @return {!string} The constraint string.

--- a/src/speech_rules/semantic_tree_rules.js
+++ b/src/speech_rules/semantic_tree_rules.js
@@ -62,24 +62,10 @@ sre.SemanticTreeRules.addContextFunction_ = goog.bind(
     sre.SemanticTreeRules.mathStore.contextFunctions);
 
 
-/** @private */
-sre.SemanticTreeRules.addCustomQuery_ = goog.bind(
-    sre.SemanticTreeRules.mathStore.customQueries.add,
-    sre.SemanticTreeRules.mathStore.customQueries);
-
-
-/** @private */
-sre.SemanticTreeRules.addCustomString_ = goog.bind(
-    sre.SemanticTreeRules.mathStore.customStrings.add,
-    sre.SemanticTreeRules.mathStore.customStrings);
-
-
 goog.scope(function() {
 var defineRule = sre.SemanticTreeRules.defineRule_;
 var defineRuleAlias = sre.SemanticTreeRules.defineRuleAlias_;
 
-var addCQF = sre.SemanticTreeRules.addCustomQuery_;
-var addCSF = sre.SemanticTreeRules.addCustomString_;
 var addCTXF = sre.SemanticTreeRules.addContextFunction_;
 
 
@@ -90,9 +76,6 @@ var addCTXF = sre.SemanticTreeRules.addContextFunction_;
 sre.SemanticTreeRules.initCustomFunctions_ = function() {
   addCTXF('CTXFnodeCounter', sre.StoreUtil.nodeCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
-
-  addCQF('CQFhideFont', sre.MathmlStoreUtil.hideFont);
-  addCSF('CSFshowFont', sre.MathmlStoreUtil.showFont);
 };
 
 
@@ -205,14 +188,16 @@ sre.SemanticTreeRules.initSemanticRules_ = function() {
   // Font rules
   defineRule(
       'font', 'default.default',
-      '[t] @font; [n] CQFhideFont; [t] CSFshowFont',
-      'self::*', '@font', '@font!="normal"');
+      '[t] @font; [n] self::* (grammar:ignoreFont=@font)',
+      'self::*', '@font', 'not(contains(@grammar, "ignoreFont"))',
+      '@font!="normal"');
 
   defineRule(
       'font-identifier-short', 'default.default',
-      '[t] @font; [n] CQFhideFont; [t] CSFshowFont',
+      '[t] @font; [n] self::* (grammar:ignoreFont=@font)',
       'self::identifier', 'string-length(text())=1',
-      '@font', '@font="normal"', '""=translate(text(), ' +
+      '@font', 'not(contains(@grammar, "ignoreFont"))', '@font="normal"',
+      '""=translate(text(), ' +
       '"abcdefghijklmnopqrstuvwxyz\u03B1\u03B2\u03B3\u03B4' +
       '\u03B5\u03B6\u03B7\u03B8\u03B9\u03BA\u03BB\u03BC\u03BD\u03BE\u03BF' +
       '\u03C0\u03C1\u03C2\u03C3\u03C4\u03C5\u03C6\u03C7\u03C8\u03C9' +
@@ -223,14 +208,16 @@ sre.SemanticTreeRules.initSemanticRules_ = function() {
 
   defineRule(
       'font-identifier', 'default.default',
-      '[t] @font; [n] CQFhideFont; [t] CSFshowFont',
+      '[t] @font; [n] self::* (grammar:ignoreFont=@font)',
       'self::identifier', 'string-length(text())=1',
-      '@font', '@font="normal"', '@role!="unit"');
+      '@font', '@font="normal"', 'not(contains(@grammar, "ignoreFont"))',
+      '@role!="unit"');
 
   defineRule(
       'omit-font', 'default.default',
-      '[n] CQFhideFont; [t] CSFshowFont',
-      'self::identifier', 'string-length(text())=1', '@font', '@font="italic"');
+      '[n] self::* (grammar:ignoreFont=@font)',
+      'self::identifier', 'string-length(text())=1', '@font',
+      'not(contains(@grammar, "ignoreFont"))', '@font="italic"');
 
   // Fraction
   defineRule(

--- a/src/speech_rules/semantic_tree_rules.js
+++ b/src/speech_rules/semantic_tree_rules.js
@@ -456,7 +456,7 @@ sre.SemanticTreeRules.initSemanticRules_ = function() {
 
   defineRule(
       'unit', 'default.default',
-      '[t] text() (annotation:unit, preprocess)',
+      '[t] text() (grammar:annotation="unit", preprocess)',
       'self::identifier', '@role="unit"');
   defineRule(
       'unit-square', 'default.default',

--- a/tests/api_test.js
+++ b/tests/api_test.js
@@ -220,7 +220,7 @@ sre.ApiTest.prototype.testToJson = function() {
 /**
  * Test for semantic tree API.
  */
-sre.ApiTest.prototype.testToDescription = function() {
+sre.ApiTest.prototype.untestToDescription = function() {
   this.executeTest(
       'toDescription',
       sre.ApiTest.QUADRATIC,

--- a/tests/mathml_cloud_test.js
+++ b/tests/mathml_cloud_test.js
@@ -193,7 +193,7 @@ sre.MathmlCloudTest.prototype.testGermanFonts = function() {
 
 
 /**
- * Testing German fonts.
+ * Testing other fonts.
  */
 sre.MathmlCloudTest.prototype.testOtherFonts = function() {
   this.executeRuleTest('<mi>m</mi>', 'm');


### PR DESCRIPTION
New data structure to keep grammatical information and pass it on during the rule dispatch.
Gets rid of some of the hacks introduced for determinants, font handling, etc. 

Still to do: Get rid of the explicit preprocess flag. This could be avoided if we were to process and finalise all auditory descriptions immediately. That is a left-over artefact of ChromeVox and the symbol mappings running in the background page.