### PR TITLE
Fixes MathJax A11Y issue #176.

### DIFF
--- a/src/speech_rules/abstraction_rules.js
+++ b/src/speech_rules/abstraction_rules.js
@@ -266,7 +266,7 @@ sre.AbstractionRules.initAbstractionRules_ = function() {
       'abstr-superscript', 'mathspeak.default',
       '[t] "collapsed power"',
       'self::superscript', '@alternative',
-      'self::*', 'self::*', 'self::*'
+      'self::*', 'self::*', 'self::*', 'self::*'
   );
   defineSpecialisedRule(
       'abstr-superscript', 'mathspeak.default', 'mathspeak.brief'


### PR DESCRIPTION
Forces reordering of superscript rules to promote abstractions.