### PR TITLE
Separate constraint functions

### DIFF
--- a/resources/doc/notes.org
+++ b/resources/doc/notes.org
@@ -149,8 +149,6 @@ https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation
 
 *** In particular ordinalCounter + Prefix methods.
 
-*** nodeCounter in MS vs nodeCounterCS in CS.
-
 *** the tensor methods
 
 ** We need to generate unique names for the constraint functions. That means we can't share!

--- a/resources/doc/notes.org
+++ b/resources/doc/notes.org
@@ -149,4 +149,12 @@ https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation
 
 *** In particular ordinalCounter + Prefix methods.
 
+*** nodeCounter in MS vs nodeCounterCS in CS.
 
+*** the tensor methods
+
+** We need to generate unique names for the constraint functions. That means we can't share!
+
+** Alternatively, have some pool of base C functions and add only what you need.
+
+*** In particular functions referring to localisable elements should be in that category.

--- a/resources/doc/notes.org
+++ b/resources/doc/notes.org
@@ -158,3 +158,40 @@ https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation
 ** Alternatively, have some pool of base C functions and add only what you need.
 
 *** In particular functions referring to localisable elements should be in that category.
+
+** Solution: Introduce a context for functions.
+
+*** Context could inherit others.
+    Not sure if that is desirable. Don't implement yet.
+
+*** Function gets context assigned.
+    No, function lives in a context. Thus different contexts can have functions
+    of the same name. Speech rules get contexts.
+
+*** Each speech rule is defined exactly once!
+    At that point it gets the context of the store it is defined.  Context is
+    set in the addRule method of the store.  This context is retained even if it
+    is sorted into a combined new store.  Combined stores do not need combined
+    contexts. I.e., context of a combined store will be empty. This could be
+    changed once we allow for inheritance of stores or contexts.
+
+*** How to exploit contexts in the tests (which are run in the trie nodes)
+
+**** In addNode_ 
+     We need to add the store of the rule (or at least the context of the rule
+     to be added), not of the overall trie!
+
+**** Replace this.store_ with this.context_
+
+*** In speech rule engine redirect custom tests
+
+**** evaluateTree_: 
+     Use the rule context after the rule lookup, instead of activeStore_
+
+**** constructString:
+     Use rule instead of activeStore_ or refactor to context
+
+**** evaluateNodeList_
+     Context functions need to be looked up in the rule context.
+
+*** Ultimately we only need combined tries, not stores as custom functions will not be added.

--- a/resources/doc/notes.org
+++ b/resources/doc/notes.org
@@ -18,7 +18,7 @@
    http://codepen.io/pkra/pen/jEodYw
    http://codepen.io/mathjax/pen/dgJHx
 
-* TODO List for mathml integration
+* DONE List for mathml integration
 
 ** [DONE] Parent attribute in outermost wrapped node should go to inner node.
 
@@ -143,7 +143,7 @@ https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation
 
 
 
-* TODO Separate CQF function calls etc. clearly by rule set.
+* DONE Separate CQF function calls etc. clearly by rule set.
 
 ** Separate all Number methods properly.
 

--- a/resources/doc/notes.org
+++ b/resources/doc/notes.org
@@ -145,18 +145,6 @@ https://en.wikipedia.org/wiki/Bra%E2%80%93ket_notation
 
 * DONE Separate CQF function calls etc. clearly by rule set.
 
-** Separate all Number methods properly.
-
-*** In particular ordinalCounter + Prefix methods.
-
-*** the tensor methods
-
-** We need to generate unique names for the constraint functions. That means we can't share!
-
-** Alternatively, have some pool of base C functions and add only what you need.
-
-*** In particular functions referring to localisable elements should be in that category.
-
 ** Solution: Introduce a context for functions.
 
 *** Context could inherit others.

--- a/src/indexing/trie.js
+++ b/src/indexing/trie.js
@@ -39,7 +39,7 @@ goog.require('sre.TrieNodeFactory');
 sre.Trie = function(store) {
   this.store = store;
   this.root = sre.TrieNodeFactory.getNode(
-      sre.TrieNode.Kind.ROOT, '', this.store);
+      sre.TrieNode.Kind.ROOT, '', this.store.context);
 };
 
 
@@ -49,14 +49,15 @@ sre.Trie = function(store) {
  */
 sre.Trie.prototype.addRule = function(rule) {
   var node = this.root;
+  var context = rule.context;
   var dynamicCstr = rule.dynamicCstr.getValues();
   for (var i = 0, l = dynamicCstr.length; i < l; i++) {
-    node = this.addNode_(node, dynamicCstr[i], sre.TrieNode.Kind.DYNAMIC);
+    node = this.addNode_(node, dynamicCstr[i], sre.TrieNode.Kind.DYNAMIC, context);
   }
-  node = this.addNode_(node, rule.precondition.query, sre.TrieNode.Kind.QUERY);
+  node = this.addNode_(node, rule.precondition.query, sre.TrieNode.Kind.QUERY, context);
   var booleans = rule.precondition.constraints;
   for (i = 0, l = booleans.length; i < l; i++) {
-    node = this.addNode_(node, booleans[i], sre.TrieNode.Kind.BOOLEAN);
+    node = this.addNode_(node, booleans[i], sre.TrieNode.Kind.BOOLEAN, context);
   }
   node.setRule(rule);
 };
@@ -67,13 +68,14 @@ sre.Trie.prototype.addRule = function(rule) {
  * @param {sre.TrieNode} node The current node in the trie.
  * @param {string} constraint The constraint string.
  * @param {sre.TrieNode.Kind} kind The kind of node.
+ * @param {sre.SpeechRuleContext} context The context of the speech rule to add.
  * @return {sre.TrieNode} The trie node corresponding to the constraint.
  * @private
  */
-sre.Trie.prototype.addNode_ = function(node, constraint, kind) {
+sre.Trie.prototype.addNode_ = function(node, constraint, kind, context) {
   var nextNode = node.getChild(constraint);
   if (!nextNode) {
-    nextNode = sre.TrieNodeFactory.getNode(kind, constraint, this.store);
+    nextNode = sre.TrieNodeFactory.getNode(kind, constraint, context);
     node.addChild(nextNode);
   }
   return nextNode;

--- a/src/indexing/trie_node_factory.js
+++ b/src/indexing/trie_node_factory.js
@@ -34,19 +34,19 @@ goog.require('sre.StaticTrieNode');
  * Generates a trie node of a given kind in the given rule store.
  * @param {sre.TrieNode.Kind} kind The kind of trie nodes.
  * @param {string} constraint The constraint the trie node is generated for.
- * @param {sre.SpeechRuleStore} store The rule store.
+ * @param {sre.SpeechRuleContext} context A function context.
  * @return {?sre.TrieNode} The newly generated trie node.
  */
-sre.TrieNodeFactory.getNode = function(kind, constraint, store) {
+sre.TrieNodeFactory.getNode = function(kind, constraint, context) {
   switch (kind) {
     case sre.TrieNode.Kind.ROOT:
       return new sre.RootTrieNode();
     case sre.TrieNode.Kind.DYNAMIC:
       return new sre.DynamicTrieNode(constraint);
     case sre.TrieNode.Kind.QUERY:
-      return new sre.QueryTrieNode(constraint, store);
+      return new sre.QueryTrieNode(constraint, context);
     case sre.TrieNode.Kind.BOOLEAN:
-      return new sre.BooleanTrieNode(constraint, store);
+      return new sre.BooleanTrieNode(constraint, context);
     default:
       return null;
   }
@@ -160,10 +160,10 @@ sre.TrieNodeFactory.constraintTest_ = function(constraint) {
  * @constructor
  * @extends {sre.StaticTrieNode}
  * @param {string} constraint The constraint the node represents.
- * @param {sre.SpeechRuleStore} store The rule store.
+ * @param {sre.SpeechRuleContext} context The rule context.
  */
-sre.QueryTrieNode = function(constraint, store) {
-  this.store_ = store;
+sre.QueryTrieNode = function(constraint, context) {
+  this.context_ = context;
   sre.QueryTrieNode.base(this, 'constructor', constraint,
                          sre.TrieNodeFactory.constraintTest_(constraint));
   this.kind = sre.TrieNode.Kind.QUERY;
@@ -176,7 +176,7 @@ goog.inherits(sre.QueryTrieNode, sre.StaticTrieNode);
  */
 sre.QueryTrieNode.prototype.applyTest = function(object) {
   return this.test ? this.test(object) :
-      this.store_.applyQuery(object, this.constraint) === object;
+      this.context_.applyQuery(object, this.constraint) === object;
 };
 
 
@@ -185,10 +185,10 @@ sre.QueryTrieNode.prototype.applyTest = function(object) {
  * @constructor
  * @extends {sre.StaticTrieNode}
  * @param {string} constraint The constraint the node represents.
- * @param {sre.SpeechRuleStore} store The rule store.
+ * @param {sre.SpeechRuleContext} context The rule context.
  */
-sre.BooleanTrieNode = function(constraint, store) {
-  this.store_ = store;
+sre.BooleanTrieNode = function(constraint, context) {
+  this.context_ = context;
   sre.BooleanTrieNode.base(
       this, 'constructor', constraint,
       sre.TrieNodeFactory.constraintTest_(constraint));
@@ -202,5 +202,5 @@ goog.inherits(sre.BooleanTrieNode, sre.StaticTrieNode);
  */
 sre.BooleanTrieNode.prototype.applyTest = function(object) {
   return this.test ? this.test(object) :
-      this.store_.applyConstraint(object, this.constraint);
+      this.context_.applyConstraint(object, this.constraint);
 };

--- a/src/rule_engine/base_rule_store.js
+++ b/src/rule_engine/base_rule_store.js
@@ -30,11 +30,10 @@ goog.require('sre.DomUtil');
 goog.require('sre.DynamicCstr');
 goog.require('sre.Engine');
 goog.require('sre.SpeechRule');
+goog.require('sre.SpeechRuleContext');
 goog.require('sre.SpeechRuleEvaluator');
-goog.require('sre.SpeechRuleFunctions');
 goog.require('sre.SpeechRuleStore');
 goog.require('sre.Trie');
-goog.require('sre.XpathUtil');
 
 
 
@@ -44,23 +43,17 @@ goog.require('sre.XpathUtil');
  * @implements {sre.SpeechRuleStore}
  */
 sre.BaseRuleStore = function() {
-  /**
-   * Set of custom query functions for the store.
-   * @type {sre.SpeechRuleFunctions.CustomQueries}
-   */
-  this.customQueries = new sre.SpeechRuleFunctions.CustomQueries();
 
   /**
-   * Set of custom strings for the store.
-   * @type {sre.SpeechRuleFunctions.CustomStrings}
+   * Context for custom functions of this rule store.
+   * @type {sre.SpeechRuleContext}
    */
-  this.customStrings = new sre.SpeechRuleFunctions.CustomStrings();
+  this.context = new sre.SpeechRuleContext();
 
-  /**
-   * Set of context functions for the store.
-   * @type {sre.SpeechRuleFunctions.ContextFunctions}
-   */
-  this.contextFunctions = new sre.SpeechRuleFunctions.ContextFunctions();
+  // TODO: Temporary shortcuts for ease of goog.bind in store definitions.
+  this.customQueries = this.context.customQueries;
+  this.customStrings = this.context.customStrings;
+  this.contextFunctions = this.context.contextFunctions;
 
   /**
    * Set of speech rules in the store.
@@ -146,6 +139,7 @@ sre.BaseRuleStore.prototype.defineRule = function(
  * @override
  */
 sre.BaseRuleStore.prototype.addRule = function(rule) {
+  rule.context = this.context;
   this.trie.addRule(rule);
   this.speechRules_.unshift(rule);
 };
@@ -198,13 +192,13 @@ sre.BaseRuleStore.prototype.evaluateDefault = function(node) {
  */
 sre.BaseRuleStore.prototype.debugSpeechRule = function(rule, node) {
   var prec = rule.precondition;
-  var queryResult = this.applyQuery(node, prec.query);
+  var queryResult = rule.context.applyQuery(node, prec.query);
   sre.Debugger.getInstance().output(
       prec.query, queryResult ? queryResult.toString() : queryResult);
   prec.constraints.forEach(
       goog.bind(function(cstr) {
         sre.Debugger.getInstance().output(
-            cstr, this.applyConstraint(node, cstr));},
+            cstr, rule.context.applyConstraint(node, cstr));},
       this));
 };
 
@@ -233,64 +227,6 @@ sre.BaseRuleStore.prototype.removeDuplicates = function(rule) {
       this.speechRules_.splice(i, 1);
     }
   }
-};
-
-
-/**
- * Checks if we have a custom query and applies it. Otherwise returns null.
- * @param {!Node} node The initial node.
- * @param {string} funcName A function name.
- * @return {Array.<Node>} The list of resulting nodes.
- */
-sre.BaseRuleStore.prototype.applyCustomQuery = function(
-    node, funcName) {
-  var func = this.customQueries.lookup(funcName);
-  return func ? func(node) : null;
-};
-
-
-/**
- * Applies either an Xpath selector or a custom query to the node
- * and returns the resulting node list.
- * @param {!Node} node The initial node.
- * @param {string} expr An Xpath expression string or a name of a custom
- *     query.
- * @return {Array.<Node>} The list of resulting nodes.
- */
-sre.BaseRuleStore.prototype.applySelector = function(node, expr) {
-  var result = this.applyCustomQuery(node, expr);
-  return result || sre.XpathUtil.evalXPath(expr, node);
-};
-
-
-/**
- * Applies either an Xpath selector or a custom query to the node
- * and returns the first result.
- * @param {!Node} node The initial node.
- * @param {string} expr An Xpath expression string or a name of a custom
- *     query.
- * @return {Node} The resulting node.
- */
-sre.BaseRuleStore.prototype.applyQuery = function(node, expr) {
-  var results = this.applySelector(node, expr);
-  if (results.length > 0) {
-    return results[0];
-  }
-  return null;
-};
-
-
-/**
- * Applies either an Xpath selector or a custom query to the node and returns
- * true if the application yields a non-empty result.
- * @param {!Node} node The initial node.
- * @param {string} expr An Xpath expression string or a name of a custom
- *     query.
- * @return {boolean} True if application was successful.
- */
-sre.BaseRuleStore.prototype.applyConstraint = function(node, expr) {
-  var result = this.applyQuery(node, expr);
-  return !!result || sre.XpathUtil.evaluateBoolean(expr, node);
 };
 
 

--- a/src/rule_engine/speech_rule.js
+++ b/src/rule_engine/speech_rule.js
@@ -51,6 +51,8 @@ sre.SpeechRule = function(name, dynamic, prec, action) {
   this.precondition = prec;
   /** @type {sre.SpeechRule.Action} */
   this.action = action;
+  /** @type {sre.SpeechRuleContext} */
+  this.context = null;
 };
 
 

--- a/src/rule_engine/speech_rule_context.js
+++ b/src/rule_engine/speech_rule_context.js
@@ -1,0 +1,137 @@
+// Copyright 2019 Volker Sorge
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Context for custom functions of a speech rule.
+ *
+ * @author v.sorge@mathjax.org (Volker Sorge)
+ */
+
+goog.provide('sre.SpeechRuleContext');
+
+goog.require('sre.SpeechRuleFunctions');
+goog.require('sre.XpathUtil');
+
+
+
+/**
+ * @constructor
+ */
+sre.SpeechRuleContext = function() {
+
+  /**
+   * Set of custom query functions for the store.
+   * @type {sre.SpeechRuleFunctions.CustomQueries}
+   */
+  this.customQueries = new sre.SpeechRuleFunctions.CustomQueries();
+
+  /**
+   * Set of custom strings for the store.
+   * @type {sre.SpeechRuleFunctions.CustomStrings}
+   */
+  this.customStrings = new sre.SpeechRuleFunctions.CustomStrings();
+
+  /**
+   * Set of context functions for the store.
+   * @type {sre.SpeechRuleFunctions.ContextFunctions}
+   */
+  this.contextFunctions = new sre.SpeechRuleFunctions.ContextFunctions();
+
+};
+
+
+/**
+ * Checks if we have a custom query and applies it. Otherwise returns null.
+ * @param {!Node} node The initial node.
+ * @param {string} funcName A function name.
+ * @return {Array.<Node>} The list of resulting nodes.
+ */
+sre.SpeechRuleContext.prototype.applyCustomQuery = function(
+    node, funcName) {
+  var func = this.customQueries.lookup(funcName);
+  return func ? func(node) : null;
+};
+
+
+/**
+ * Applies either an Xpath selector or a custom query to the node
+ * and returns the resulting node list.
+ * @param {!Node} node The initial node.
+ * @param {string} expr An Xpath expression string or a name of a custom
+ *     query.
+ * @return {Array.<Node>} The list of resulting nodes.
+ */
+sre.SpeechRuleContext.prototype.applySelector = function(node, expr) {
+  var result = this.applyCustomQuery(node, expr);
+  return result || sre.XpathUtil.evalXPath(expr, node);
+};
+
+
+/**
+ * Applies either an Xpath selector or a custom query to the node
+ * and returns the first result.
+ * @param {!Node} node The initial node.
+ * @param {string} expr An Xpath expression string or a name of a custom
+ *     query.
+ * @return {Node} The resulting node.
+ */
+sre.SpeechRuleContext.prototype.applyQuery = function(node, expr) {
+  var results = this.applySelector(node, expr);
+  if (results.length > 0) {
+    return results[0];
+  }
+  return null;
+};
+
+
+/**
+ * Applies either an Xpath selector or a custom query to the node and returns
+ * true if the application yields a non-empty result.
+ * @param {!Node} node The initial node.
+ * @param {string} expr An Xpath expression string or a name of a custom
+ *     query.
+ * @return {boolean} True if application was successful.
+ */
+sre.SpeechRuleContext.prototype.applyConstraint = function(node, expr) {
+  var result = this.applyQuery(node, expr);
+  return !!result || sre.XpathUtil.evaluateBoolean(expr, node);
+};
+
+
+/**
+ * Constructs a string from the node and the given expression.
+ * @param {!Node} node The initial node.
+ * @param {string} expr An Xpath expression string, a name of a custom
+ *     function or a string.
+ * @return {string} The result of applying expression to node.
+ */
+sre.SpeechRuleContext.prototype.constructString = function(node, expr) {
+  if (!expr) {
+    return '';
+  }
+  if (expr.charAt(0) == '"') {
+    return expr.slice(1, -1);
+  }
+  var func = this.customStrings.lookup(expr);
+  if (func) {
+    // We always return the result of the custom function, in case it
+    // deliberately computes the empty string!
+    return func(node);
+  }
+  // Finally we assume expr to be an xpath expression and calculate a string
+  // value from the node.
+  return sre.XpathUtil.evaluateString(expr, node);
+};
+
+

--- a/src/rule_engine/speech_rule_engine.js
+++ b/src/rule_engine/speech_rule_engine.js
@@ -40,7 +40,6 @@ goog.require('sre.MathMap');
 goog.require('sre.MathStore');
 goog.require('sre.SpeechRule');
 goog.require('sre.SpeechRuleStores');
-goog.require('sre.XpathUtil');
 
 
 
@@ -120,32 +119,6 @@ sre.SpeechRuleEngine.prototype.parameterize_ = function(ruleSets) {
     }
   }
   this.updateEngine();
-};
-
-
-/**
- * Constructs a string from the node and the given expression.
- * @param {!Node} node The initial node.
- * @param {string} expr An Xpath expression string, a name of a custom
- *     function or a string.
- * @return {string} The result of applying expression to node.
- */
-sre.SpeechRuleEngine.prototype.constructString = function(node, expr) {
-  if (!expr) {
-    return '';
-  }
-  if (expr.charAt(0) == '"') {
-    return expr.slice(1, -1);
-  }
-  var func = this.activeStore_.customStrings.lookup(expr);
-  if (func) {
-    // We always return the result of the custom function, in case it
-    // deliberately computes the empty string!
-    return func(node);
-  }
-  // Finally we assume expr to be an xpath expression and calculate a string
-  // value from the node.
-  return sre.XpathUtil.evaluateString(expr, node);
 };
 
 
@@ -289,6 +262,7 @@ sre.SpeechRuleEngine.prototype.evaluateTree_ = function(node) {
       goog.bind(function() {
         return [rule.name, rule.dynamicCstr.toString(), node.toString()];},
       this));
+  var context = rule.context || this.activeStore_.context;
   var components = rule.action.components;
   result = [];
   for (var i = 0, component; component = components[i]; i++) {
@@ -297,29 +271,30 @@ sre.SpeechRuleEngine.prototype.evaluateTree_ = function(node) {
     var attributes = component.attributes || {};
     var multi = false;
     if (component.grammar) {
-      this.processGrammar(node, component.grammar);
+      this.processGrammar(context, node, component.grammar);
     }
     switch (component.type) {
       case sre.SpeechRule.Type.NODE:
-        var selected = this.activeStore_.applyQuery(node, content);
+        var selected = context.applyQuery(node, content);
         if (selected) {
           descrs = this.evaluateTree_(selected);
         }
         break;
       case sre.SpeechRule.Type.MULTI:
         multi = true;
-        selected = this.activeStore_.applySelector(node, content);
+        selected = context.applySelector(node, content);
         if (selected.length > 0) {
           descrs = this.evaluateNodeList_(
+              context,
               selected,
               attributes['sepFunc'],
-              this.constructString(node, attributes['separator']),
+              context.constructString(node, attributes['separator']),
               attributes['ctxtFunc'],
-              this.constructString(node, attributes['context']));
+              context.constructString(node, attributes['context']));
         }
         break;
       case sre.SpeechRule.Type.TEXT:
-        selected = this.constructString(node, content);
+        selected = context.constructString(node, content);
         if (selected) {
           descrs = [sre.AuditoryDescription.create(
               {text: selected}, {adjust: true})];
@@ -333,7 +308,7 @@ sre.SpeechRuleEngine.prototype.evaluateTree_ = function(node) {
     if (descrs[0] && !multi) {
       if (attributes['context']) {
         descrs[0]['context'] =
-            this.constructString(node, attributes['context']) +
+            context.constructString(node, attributes['context']) +
             (descrs[0]['context'] || '');
       }
       if (attributes['annotation']) {
@@ -354,28 +329,30 @@ sre.SpeechRuleEngine.prototype.evaluateTree_ = function(node) {
 
 /**
  * Evaluates a list of nodes into a list of auditory descriptions.
+ * @param {sre.SpeechRuleContext} context The function context in which to
+ *     evaluate the nodes.
  * @param {!Array.<Node>} nodes Array of nodes.
  * @param {string} sepFunc Name of a function used to compute a separator
  *     between every element.
- * @param {string} separator A string that is used as argument to the sepFunc or
+ * @param {string} sepStr A string that is used as argument to the sepFunc or
  *     interspersed directly between each node if sepFunc is not supplied.
  * @param {string} ctxtFunc Name of a function applied to compute the context
  *     for every element in the list.
- * @param {string} context Additional context string that is given to the
+ * @param {string} ctxtStr Additional context string that is given to the
  *     ctxtFunc function or used directly if ctxtFunc is not supplied.
  * @return {Array.<sre.AuditoryDescription>} A list of Auditory descriptions.
  * @private
  */
 sre.SpeechRuleEngine.prototype.evaluateNodeList_ = function(
-    nodes, sepFunc, separator, ctxtFunc, context) {
+    context, nodes, sepFunc, sepStr, ctxtFunc, ctxtStr) {
   if (nodes == []) {
     return [];
   }
-  var sep = separator || '';
-  var cont = context || '';
-  var cFunc = this.activeStore_.contextFunctions.lookup(ctxtFunc);
+  var sep = sepStr || '';
+  var cont = ctxtStr || '';
+  var cFunc = context.contextFunctions.lookup(ctxtFunc);
   var ctxtClosure = cFunc ? cFunc(nodes, cont) : function() {return cont;};
-  var sFunc = this.activeStore_.contextFunctions.lookup(sepFunc);
+  var sFunc = context.contextFunctions.lookup(sepFunc);
   var sepClosure = sFunc ? sFunc(nodes, sep) :
       function() {return sre.AuditoryDescription.create(
       {text: sep}, {translate: true});};
@@ -580,9 +557,9 @@ sre.SpeechRuleEngine.prototype.combineStores_ = function(ruleSets) {
     var store = ruleSets[name];
     store.initialize();
     store.getSpeechRules().forEach(function(x) {combined.trie.addRule(x);});
-    combined.contextFunctions.addStore(store.contextFunctions);
-    combined.customQueries.addStore(store.customQueries);
-    combined.customStrings.addStore(store.customStrings);
+    // combined.contextFunctions.addStore(store.contextFunctions);
+    // combined.customQueries.addStore(store.customQueries);
+    // combined.customStrings.addStore(store.customStrings);
   }
   combined.setSpeechRules(combined.trie.collectRules());
   this.combinedStores_[this.combinedStoreName_(Object.keys(ruleSets))] =
@@ -639,15 +616,17 @@ sre.SpeechRuleEngine.prototype.updateEngine = function() {
 
 /**
  * Processes the grammar annotations of a rule.
+ * @param {sre.SpeechRuleContext} context The function context in which to
+ *     evaluate the grammar expression.
  * @param {!Node} node The node to which the rule is applied.
  * @param {sre.Grammar.State} grammar The grammar annotations.
  */
-sre.SpeechRuleEngine.prototype.processGrammar = function(node, grammar) {
+sre.SpeechRuleEngine.prototype.processGrammar = function(context, node, grammar) {
   var assignment = {};
   for (var key in grammar) {
     var value = grammar[key];
     assignment[key] = (typeof(value) === 'string') ?
-        this.constructString(node, value) : value;
+        context.constructString(node, value) : value;
   }
   sre.Grammar.getInstance().pushState(assignment);
 };

--- a/src/speech_rules/clearspeak_french.js
+++ b/src/speech_rules/clearspeak_french.js
@@ -127,7 +127,7 @@ sre.ClearspeakFrench.addComparator_ = function() {
  */
 sre.ClearspeakFrench.initCustomFunctions_ = function() {
   addCTXF('CTXFpauseSeparator', sre.StoreUtil.pauseSeparator);
-  addCTXF('CTXFnodeCounterCS', sre.ClearspeakUtil.nodeCounter);
+  addCTXF('CTXFnodeCounter', sre.ClearspeakUtil.nodeCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
   addCSF('CSFvulgarFraction', sre.MathspeakFrenchUtil.vulgarFraction);
   addCQF('CQFvulgarFractionSmall', sre.ClearspeakUtil.isSmallVulgarFraction);
@@ -1791,7 +1791,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       'matrix', 'clearspeak.default',
       '[t] "la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); [p] (pause:long);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"rangée-:");' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"rangée-:");' +
       ' [p] (pause:long)',
       'self::matrix');
   defineRule(
@@ -1799,7 +1799,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       ' [p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', 'count(children/*)<4',
       'count(children/*[1]/children/*)<4', 'CQFcellsSimple');
@@ -1814,7 +1814,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le déterminant de la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"', 'count(children/*)<4',
       'CQFcellsSimple');
@@ -1823,7 +1823,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le déterminant de la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:");' +
+      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:");' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"');
   // Vector
@@ -1832,7 +1832,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "la matrice colonne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1860,7 +1860,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "la matrice ligne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"colonne-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"colonne-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -1899,7 +1899,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       'self::line', 'contains(@grammar, "simpleDet")');
   defineRule(
       'matrix-row', 'clearspeak.default',
-      '[m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"colonne-,- ",' +
+      '[m] children/* (ctxtFunc:CTXFnodeCounter,context:"colonne-,- ",' +
       'sepFunc:CTXFpauseSeparator,separator:"medium"); [p] (pause:long)',
       'self::row');
   defineSpecialisedRule(
@@ -1927,7 +1927,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le vecteur colonne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet); ' +
+      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet); ' +
       '[p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1949,7 +1949,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le vecteur ligne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*);' +
       ' [p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"colonne-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"colonne-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -2040,7 +2040,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines', 'clearspeak.default',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Line-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Line-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2076,7 +2076,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'cases', 'clearspeak.default',
       '[p] (pause:short); ' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Cas-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Cas-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::cases');
 
@@ -2095,7 +2095,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-cases', 'clearspeak.MultiLineLabel_Case',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Cas-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Cas-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2115,7 +2115,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-equations', 'clearspeak.MultiLineLabel_Equation',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Équation-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Équation-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2135,7 +2135,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:" Étape-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:" Étape-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2155,7 +2155,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-rows', 'clearspeak.MultiLineLabel_Row',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"rangée-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2175,7 +2175,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:" Étape-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:" Étape-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2195,7 +2195,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-constraints', 'clearspeak.MultiLineLabel_Constraint',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Contrainte-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Contrainte-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(

--- a/src/speech_rules/clearspeak_french.js
+++ b/src/speech_rules/clearspeak_french.js
@@ -127,7 +127,7 @@ sre.ClearspeakFrench.addComparator_ = function() {
  */
 sre.ClearspeakFrench.initCustomFunctions_ = function() {
   addCTXF('CTXFpauseSeparator', sre.StoreUtil.pauseSeparator);
-  addCTXF('CTXFnodeCounter', sre.ClearspeakUtil.nodeCounter);
+  addCTXF('CTXFnodeCounterCS', sre.ClearspeakUtil.nodeCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
   addCSF('CSFvulgarFraction', sre.MathspeakFrenchUtil.vulgarFraction);
   addCQF('CQFvulgarFractionSmall', sre.ClearspeakUtil.isSmallVulgarFraction);
@@ -1791,7 +1791,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       'matrix', 'clearspeak.default',
       '[t] "la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); [p] (pause:long);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"rangée-:");' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"rangée-:");' +
       ' [p] (pause:long)',
       'self::matrix');
   defineRule(
@@ -1799,7 +1799,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       ' [p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', 'count(children/*)<4',
       'count(children/*[1]/children/*)<4', 'CQFcellsSimple');
@@ -1814,7 +1814,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le déterminant de la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"', 'count(children/*)<4',
       'CQFcellsSimple');
@@ -1823,7 +1823,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le déterminant de la matrice de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:");' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:");' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"');
   // Vector
@@ -1832,7 +1832,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "la matrice colonne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1860,7 +1860,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "la matrice ligne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"colonne-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"colonne-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -1899,7 +1899,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       'self::line', 'contains(@grammar, "simpleDet")');
   defineRule(
       'matrix-row', 'clearspeak.default',
-      '[m] children/* (ctxtFunc:CTXFnodeCounter,context:"colonne-,- ",' +
+      '[m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"colonne-,- ",' +
       'sepFunc:CTXFpauseSeparator,separator:"medium"); [p] (pause:long)',
       'self::row');
   defineSpecialisedRule(
@@ -1927,7 +1927,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le vecteur colonne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"rangée-:",grammar:simpleDet); ' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",grammar:simpleDet); ' +
       '[p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1949,7 +1949,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
       '[t] "le vecteur ligne de dimension"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*);' +
       ' [p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"colonne-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"colonne-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -2040,7 +2040,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines', 'clearspeak.default',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Line-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Line-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2076,7 +2076,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'cases', 'clearspeak.default',
       '[p] (pause:short); ' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Cas-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Cas-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::cases');
 
@@ -2095,7 +2095,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-cases', 'clearspeak.MultiLineLabel_Case',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Cas-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Cas-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2115,7 +2115,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-equations', 'clearspeak.MultiLineLabel_Equation',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Équation-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Équation-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2135,7 +2135,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:" Étape-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:" Étape-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2155,7 +2155,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-rows', 'clearspeak.MultiLineLabel_Row',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"rangée-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"rangée-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2175,7 +2175,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:" Étape-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:" Étape-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2195,7 +2195,7 @@ sre.ClearspeakFrench.initClearspeakFrench_ = function() {
   defineRule(
       'lines-constraints', 'clearspeak.MultiLineLabel_Constraint',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Contrainte-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Contrainte-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(

--- a/src/speech_rules/clearspeak_rules.js
+++ b/src/speech_rules/clearspeak_rules.js
@@ -125,7 +125,7 @@ sre.ClearspeakRules.addComparator_ = function() {
  */
 sre.ClearspeakRules.initCustomFunctions_ = function() {
   addCTXF('CTXFpauseSeparator', sre.StoreUtil.pauseSeparator);
-  addCTXF('CTXFnodeCounterCS', sre.ClearspeakUtil.nodeCounter);
+  addCTXF('CTXFnodeCounter', sre.ClearspeakUtil.nodeCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
   addCSF('CSFvulgarFraction', sre.MathspeakUtil.vulgarFraction);
   addCQF('CQFvulgarFractionSmall', sre.ClearspeakUtil.isSmallVulgarFraction);
@@ -1754,7 +1754,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       'matrix', 'clearspeak.default',
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix"; [p] (pause:long);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Row-:");' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Row-:");' +
       ' [p] (pause:long)',
       'self::matrix');
   defineRule(
@@ -1762,7 +1762,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix";' +
       ' [p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', 'count(children/*)<4',
       'count(children/*[1]/children/*)<4', 'CQFcellsSimple');
@@ -1777,7 +1777,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the determinant of the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"', 'count(children/*)<4',
       'CQFcellsSimple');
@@ -1786,7 +1786,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the determinant of the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:");' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Row-:");' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"');
   // Vector
@@ -1795,7 +1795,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "column matrix"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1823,7 +1823,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "row matrix"; ' +
       '[p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Column-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Column-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -1862,7 +1862,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       'self::line', 'contains(@grammar, "simpleDet")');
   defineRule(
       'matrix-row', 'clearspeak.default',
-      '[m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Column-,- ",' +
+      '[m] children/* (ctxtFunc:CTXFnodeCounter,context:"Column-,- ",' +
       'sepFunc:CTXFpauseSeparator,separator:"medium"); [p] (pause:long)',
       'self::row');
   defineSpecialisedRule(
@@ -1890,7 +1890,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "column vector"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet); ' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet); ' +
       '[p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1912,7 +1912,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "row vector";' +
       ' [p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounterCS,context:"Column-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounter,context:"Column-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -2003,7 +2003,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines', 'clearspeak.default',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Line-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Line-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2039,7 +2039,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'cases', 'clearspeak.default',
       '[p] (pause:short); ' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Case-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Case-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::cases');
 
@@ -2058,7 +2058,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-cases', 'clearspeak.MultiLineLabel_Case',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Case-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Case-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2078,7 +2078,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-equations', 'clearspeak.MultiLineLabel_Equation',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Equation-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Equation-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2098,7 +2098,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Step-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Step-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2118,7 +2118,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-rows', 'clearspeak.MultiLineLabel_Row',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Row-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Row-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2138,7 +2138,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Step-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Step-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2158,7 +2158,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-constraints', 'clearspeak.MultiLineLabel_Constraint',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Constraint-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Constraint-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(

--- a/src/speech_rules/clearspeak_rules.js
+++ b/src/speech_rules/clearspeak_rules.js
@@ -125,7 +125,7 @@ sre.ClearspeakRules.addComparator_ = function() {
  */
 sre.ClearspeakRules.initCustomFunctions_ = function() {
   addCTXF('CTXFpauseSeparator', sre.StoreUtil.pauseSeparator);
-  addCTXF('CTXFnodeCounter', sre.ClearspeakUtil.nodeCounter);
+  addCTXF('CTXFnodeCounterCS', sre.ClearspeakUtil.nodeCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
   addCSF('CSFvulgarFraction', sre.MathspeakUtil.vulgarFraction);
   addCQF('CQFvulgarFractionSmall', sre.ClearspeakUtil.isSmallVulgarFraction);
@@ -1754,7 +1754,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       'matrix', 'clearspeak.default',
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix"; [p] (pause:long);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Row-:");' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Row-:");' +
       ' [p] (pause:long)',
       'self::matrix');
   defineRule(
@@ -1762,7 +1762,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix";' +
       ' [p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', 'count(children/*)<4',
       'count(children/*[1]/children/*)<4', 'CQFcellsSimple');
@@ -1777,7 +1777,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the determinant of the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"', 'count(children/*)<4',
       'CQFcellsSimple');
@@ -1786,7 +1786,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the determinant of the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "matrix"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Row-:");' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:");' +
       ' [p] (pause:long)',
       'self::matrix', '@role="determinant"');
   // Vector
@@ -1795,7 +1795,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "column matrix"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1823,7 +1823,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "row matrix"; ' +
       '[p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Column-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Column-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -1862,7 +1862,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       'self::line', 'contains(@grammar, "simpleDet")');
   defineRule(
       'matrix-row', 'clearspeak.default',
-      '[m] children/* (ctxtFunc:CTXFnodeCounter,context:"Column-,- ",' +
+      '[m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Column-,- ",' +
       'sepFunc:CTXFpauseSeparator,separator:"medium"); [p] (pause:long)',
       'self::row');
   defineSpecialisedRule(
@@ -1890,7 +1890,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "column vector"; ' +
       '[p] (pause:long); [m] children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Row-:",grammar:simpleDet); ' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Row-:",grammar:simpleDet); ' +
       '[p] (pause:long)',
       'self::vector');
   defineSpecialisedRule(
@@ -1912,7 +1912,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
       '[t] "the"; [t] count(children/*);  [t] "by";' +
       '[t] count(children/*[1]/children/*); [t] "row vector";' +
       ' [p] (pause:long); [m] children/*[1]/children/* ' +
-      '(ctxtFunc:CTXFnodeCounter,context:"Column-:",grammar:simpleDet);' +
+      '(ctxtFunc:CTXFnodeCounterCS,context:"Column-:",grammar:simpleDet);' +
       ' [p] (pause:long)',
       'self::matrix', '@role="rowvector"');
   defineSpecialisedRule(
@@ -2003,7 +2003,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines', 'clearspeak.default',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Line-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Line-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2039,7 +2039,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'cases', 'clearspeak.default',
       '[p] (pause:short); ' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Case-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Case-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::cases');
 
@@ -2058,7 +2058,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-cases', 'clearspeak.MultiLineLabel_Case',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Case-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Case-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2078,7 +2078,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-equations', 'clearspeak.MultiLineLabel_Equation',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Equation-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Equation-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2098,7 +2098,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Step-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Step-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2118,7 +2118,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-rows', 'clearspeak.MultiLineLabel_Row',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Row-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Row-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2138,7 +2138,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-steps', 'clearspeak.MultiLineLabel_Step',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Step-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Step-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(
@@ -2158,7 +2158,7 @@ sre.ClearspeakRules.initClearspeakRules_ = function() {
   defineRule(
       'lines-constraints', 'clearspeak.MultiLineLabel_Constraint',
       '[p] (pause:short);' +
-      ' [m] children/* (ctxtFunc:CTXFnodeCounter,context:"Constraint-:",' +
+      ' [m] children/* (ctxtFunc:CTXFnodeCounterCS,context:"Constraint-:",' +
       'sepFunc:CTXFpauseSeparator,separator:"long");' +
       ' [p] (pause:long)', 'self::table');
   defineRuleAlias(

--- a/src/speech_rules/mathspeak_french.js
+++ b/src/speech_rules/mathspeak_french.js
@@ -148,7 +148,7 @@ sre.MathspeakFrench.initCustomFunctions_ = function() {
   addCSF('CSFunderscript', sre.MathspeakUtil.nestedUnderscore);
   addCSF('CSFoverscript', sre.MathspeakUtil.nestedOverscore);
 
-  addCTXF('CTXFordinalCounterFr', sre.MathspeakFrenchUtil.ordinalCounter);
+  addCTXF('CTXFordinalCounter', sre.MathspeakFrenchUtil.ordinalCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
 
   // Layout related.
@@ -1034,39 +1034,39 @@ sre.MathspeakFrench.initMathspeakFrench_ = function() {
       'matrix', 'mathspeak.default',
       '[t] "début matrice"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin matrice"',
       'self::matrix');
   defineRule(
       'matrix', 'mathspeak.sbrief',
       '[t] "matrice"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin matrice"', 'self::matrix');
   defineRuleAlias(
       'matrix', 'self::vector');
 
   defineRule(
       'matrix-row', 'mathspeak.default',
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"colonne");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"colonne");' +
       '[p] (pause: 200)',
       'self::row');
   defineRule(
       'row-with-label', 'mathspeak.default',
       '[t] "avec étiquette"; [n] content/*[1]; [t] "fin étiquette"(pause: 200); ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"colonne")',
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"colonne")',
       'self::row', 'content');
   defineRule(
       'row-with-label', 'mathspeak.brief',
       '[t] "étiquette"; [n] content/*[1]; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"colonne")',
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"colonne")',
       'self::row', 'content');
   defineSpecialisedRule(
       'row-with-label', 'mathspeak.brief', 'mathspeak.sbrief');
   defineRule(
       'row-with-text-label', 'mathspeak.sbrief',
       '[t] "étiquette"; [t] CSFRemoveParens;' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"colonne")',
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"colonne")',
       'self::row', 'content', 'name(content/cell/children/*[1])="text"');
   defineRule(
       'empty-row', 'mathspeak.default',
@@ -1088,28 +1088,28 @@ sre.MathspeakFrench.initMathspeakFrench_ = function() {
       'determinant', 'mathspeak.default',
       '[t] "début déterminant"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*); [t] "";' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin déterminant"',
       'self::matrix', '@role="determinant"');
   defineSpecialisedRule(
       'determinant', 'mathspeak.default', 'mathspeak.sbrief',
       '[t] "déterminant"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin déterminant"');
 
   defineRule(
       'determinant-simple', 'mathspeak.default',
       '[t] "début déterminant"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée",' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée",' +
       'grammar:simpleDet); [t] "fin déterminant"',
       'self::matrix', '@role="determinant"', 'CQFdetIsSimple');
   defineSpecialisedRule(
       'determinant-simple', 'mathspeak.default', 'mathspeak.sbrief',
       '[t] "déterminant"; [t] count(children/*);  [t] "par";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée",' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée",' +
       'grammar:simpleDet); [t] "fin déterminant"');
   defineRule(
       'row-simple', 'mathspeak.default',
@@ -1118,11 +1118,11 @@ sre.MathspeakFrench.initMathspeakFrench_ = function() {
 
   defineRule(
       'layout', 'mathspeak.default', '[t] "début tableau"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin tableau"', 'self::table');
   defineRule(
       'layout', 'mathspeak.sbrief', '[t] "tableau"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin tableau"', 'self::table');
 
   defineRule(
@@ -1142,12 +1142,12 @@ sre.MathspeakFrench.initMathspeakFrench_ = function() {
   defineRule(
       'cases', 'mathspeak.default', '[t] "début tableau"; ' +
       '[n] content/*[1]; [t] "élargie";' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin tableau"', 'self::cases');
   defineRule(
       'cases', 'mathspeak.sbrief', '[t] "tableau"; ' +
       '[n] content/*[1]; [t] "élargie"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterFr,context:"rangée ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"rangée ");' +
       ' [t] "fin tableau"', 'self::cases');
 
   // Multiline rules.

--- a/src/speech_rules/mathspeak_spanish.js
+++ b/src/speech_rules/mathspeak_spanish.js
@@ -144,7 +144,7 @@ sre.MathspeakSpanish.initCustomFunctions_ = function() {
   addCSF('CSFunderscript', sre.MathspeakUtil.nestedUnderscore);
   addCSF('CSFoverscript', sre.MathspeakUtil.nestedOverscore);
 
-  addCTXF('CTXFordinalCounterEs', sre.MathspeakSpanishUtil.ordinalCounter);
+  addCTXF('CTXFordinalCounter', sre.MathspeakSpanishUtil.ordinalCounter);
   addCTXF('CTXFcontentIterator', sre.MathmlStoreUtil.contentIterator);
   addCTXF('CTXFunitMultipliers', sre.MathspeakSpanishUtil.unitMultipliers);
 
@@ -997,40 +997,40 @@ sre.MathspeakSpanish.initMathspeakSpanish_ = function() {
       'matrix', 'mathspeak.default',
       '[t] "empezar matriz"; [t] count(children/*);  [t] "por";' +
       '[t] count(children/*[1]/children/*); ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar matriz"',
       'self::matrix');
   defineRule(
       'matrix', 'mathspeak.sbrief',
       '[t] "matriz"; [t] count(children/*);  [t] "por";' +
       '[t] count(children/*[1]/children/*); ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:" ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:" ");' +
       ' [t] "finalizar matriz"', 'self::matrix');
   defineRuleAlias(
       'matrix', 'self::vector');
 
   defineRule(
       'matrix-row', 'mathspeak.default',
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"columna");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"columna");' +
       '[p] (pause: 200)',
       'self::row');
   defineRule(
       'row-with-label', 'mathspeak.default',
       '[t] "con etiqueta"; [n] content/*[1]; ' +
       '[t] "finalizar etiqueta" (pause: 200); ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"columna")',
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"columna")',
       'self::row', 'content');
   defineRule(
       'row-with-label', 'mathspeak.brief',
       '[t] "etiqueta"; [n] content/*[1]; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"columna")',
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"columna")',
       'self::row', 'content');
   defineSpecialisedRule(
       'row-with-label', 'mathspeak.brief', 'mathspeak.sbrief');
   defineRule(
       'row-with-text-label', 'mathspeak.sbrief',
       '[t] "etiqueta"; [t] CSFRemoveParens;' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"columna")',
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"columna")',
       'self::row', 'content', 'name(content/cell/children/*[1])="text"');
   defineRule(
       'empty-row', 'mathspeak.default',
@@ -1049,28 +1049,28 @@ sre.MathspeakSpanish.initMathspeakSpanish_ = function() {
       'determinant', 'mathspeak.default',
       '[t] "empezar determinante"; [t] count(children/*);  [t] "por";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar determinante"',
       'self::matrix', '@role="determinant"');
   defineSpecialisedRule(
       'determinant', 'mathspeak.default', 'mathspeak.sbrief',
       '[t] "determinante"; [t] count(children/*);  [t] "por";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar determinante"');
 
   defineRule(
       'determinant-simple', 'mathspeak.default',
       '[t] "empezar determinante"; [t] count(children/*);  [t] "por";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila",' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila",' +
       'grammar:simpleDet); [t] "finalizar determinante"',
       'self::matrix', '@role="determinant"', 'CQFdetIsSimple');
   defineSpecialisedRule(
       'determinant-simple', 'mathspeak.default', 'mathspeak.sbrief',
       '[t] "determinante"; [t] count(children/*);  [t] "por";' +
       '[t] count(children/*[1]/children/*);' +
-      ' [m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila",' +
+      ' [m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila",' +
       'grammar:simpleDet); [t] "finalizar determinante"');
   defineRule(
       'row-simple', 'mathspeak.default',
@@ -1079,11 +1079,11 @@ sre.MathspeakSpanish.initMathspeakSpanish_ = function() {
 
   defineRule(
       'layout', 'mathspeak.default', '[t] "empezar esquema"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar esquema"', 'self::table');
   defineRule(
       'layout', 'mathspeak.sbrief', '[t] "esquema"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar esquema"', 'self::table');
 
   defineRule(
@@ -1102,12 +1102,12 @@ sre.MathspeakSpanish.initMathspeakSpanish_ = function() {
   defineRule(
       'cases', 'mathspeak.default', '[t] "empezar esquema"; ' +
       '[n] content/*[1]; [t] "alargada"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar esquema"', 'self::cases');
   defineRule(
       'cases', 'mathspeak.sbrief', '[t] "esquema"; ' +
       '[n] content/*[1]; [t] "alargada"; ' +
-      '[m] children/* (ctxtFunc:CTXFordinalCounterEs,context:"fila ");' +
+      '[m] children/* (ctxtFunc:CTXFordinalCounter,context:"fila ");' +
       ' [t] "finalizar esquema"', 'self::cases');
 
   // Multiline rules.

--- a/tests/clearspeak_french_rule_test.js
+++ b/tests/clearspeak_french_rule_test.js
@@ -48,12 +48,6 @@ sre.ClearspeakFrenchRuleTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['ClearspeakRules', 'ClearspeakFrench'];
-
-
   this.actual = true;
   this.setActive('ClearspeakFrench');
   this.startExamples();

--- a/tests/clearspeak_rule_test.js
+++ b/tests/clearspeak_rule_test.js
@@ -43,11 +43,6 @@ sre.ClearspeakRuleTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['ClearspeakRules'];
-
   this.setActive('ClearspeakExamples');
   this.startExamples();
 };

--- a/tests/mathml_rule_test.js
+++ b/tests/mathml_rule_test.js
@@ -40,11 +40,6 @@ sre.MathmlRuleTest = function() {
    */
   this.semantics = false;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathmlStoreRules'];
-
 };
 goog.inherits(sre.MathmlRuleTest, sre.AbstractRuleTest);
 

--- a/tests/mathspeak_embellish_french_test.js
+++ b/tests/mathspeak_embellish_french_test.js
@@ -50,13 +50,7 @@ sre.MathspeakEmbellishFrenchTest = function() {
    */
   this.locale = 'fr';
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakFrench'];
-
   this.setActive('EmbellishedSymbolsFrench');
-
 };
 goog.inherits(sre.MathspeakEmbellishFrenchTest, sre.AbstractRuleTest);
 

--- a/tests/mathspeak_embellish_spanish_test.js
+++ b/tests/mathspeak_embellish_spanish_test.js
@@ -50,13 +50,7 @@ sre.MathspeakEmbellishSpanishTest = function() {
    */
   this.locale = 'es';
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakSpanish'];
-
   this.setActive('EmbellishedSymbolsSpanish');
-
 };
 goog.inherits(sre.MathspeakEmbellishSpanishTest, sre.AbstractRuleTest);
 

--- a/tests/mathspeak_embellish_test.js
+++ b/tests/mathspeak_embellish_test.js
@@ -45,11 +45,6 @@ sre.MathspeakEmbellishTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules'];
-
   this.setActive('EmbellishedSymbolsEnglish');
 };
 goog.inherits(sre.MathspeakEmbellishTest, sre.AbstractRuleTest);

--- a/tests/mathspeak_english_test.js
+++ b/tests/mathspeak_english_test.js
@@ -45,11 +45,6 @@ sre.MathspeakEnglishTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules'];
-
   this.setActive('MathspeakEnglish');
 };
 goog.inherits(sre.MathspeakEnglishTest, sre.AbstractRuleTest);

--- a/tests/mathspeak_french_test.js
+++ b/tests/mathspeak_french_test.js
@@ -50,13 +50,7 @@ sre.MathspeakFrenchTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakFrench'];
-
   this.setActive('MathspeakFrench');
-
 };
 goog.inherits(sre.MathspeakFrenchTest, sre.AbstractRuleTest);
 

--- a/tests/mathspeak_spanish_test.js
+++ b/tests/mathspeak_spanish_test.js
@@ -50,11 +50,6 @@ sre.MathspeakSpanishTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakSpanish'];
-
   this.setActive('MathspeakSpanish');
 
 };

--- a/tests/mmlcloud_english_test.js
+++ b/tests/mmlcloud_english_test.js
@@ -47,11 +47,6 @@ sre.MmlcloudEnglishTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules'];
-
   this.setActive('MathmlCloudEnglish');
 };
 goog.inherits(sre.MmlcloudEnglishTest, sre.AbstractRuleTest);

--- a/tests/mmlcloud_french_test.js
+++ b/tests/mmlcloud_french_test.js
@@ -51,13 +51,7 @@ sre.MmlcloudFrenchTest = function() {
    */
   this.locale = 'fr';
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakFrench'];
-
   this.setActive('MathmlCloudFrench');
-
 };
 goog.inherits(sre.MmlcloudFrenchTest, sre.AbstractRuleTest);
 

--- a/tests/mmlcloud_spanish_test.js
+++ b/tests/mmlcloud_spanish_test.js
@@ -51,11 +51,6 @@ sre.MmlcloudSpanishTest = function() {
    */
   this.locale = 'es';
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakSpanish'];
-
   this.setActive('MathmlCloudSpanish');
 
 };

--- a/tests/noble_english_test.js
+++ b/tests/noble_english_test.js
@@ -46,11 +46,6 @@ sre.NobleEnglishTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules'];
-
   this.setActive('NobleSamplesEnglish');
 };
 goog.inherits(sre.NobleEnglishTest, sre.AbstractRuleTest);

--- a/tests/noble_french_test.js
+++ b/tests/noble_french_test.js
@@ -51,13 +51,7 @@ sre.NobleFrenchTest = function() {
    */
   this.locale = 'fr';
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakFrench'];
-
   this.setActive('NobleSamplesFrench');
-
 };
 goog.inherits(sre.NobleFrenchTest, sre.AbstractRuleTest);
 

--- a/tests/noble_spanish_test.js
+++ b/tests/noble_spanish_test.js
@@ -51,11 +51,6 @@ sre.NobleSpanishTest = function() {
    */
   this.locale = 'es';
 
-  /**
-   * @override
-   */
-  this.rules = ['MathspeakRules', 'MathspeakSpanish'];
-
   this.setActive('NobleSamplesSpanish');
 
 };

--- a/tests/semantic_rule_test.js
+++ b/tests/semantic_rule_test.js
@@ -45,11 +45,6 @@ sre.SemanticRuleTest = function() {
    */
   this.semantics = true;
 
-  /**
-   * @override
-   */
-  this.rules = ['SemanticTreeRules'];
-
   this.setActive('SemanticTreeRules');
 };
 goog.inherits(sre.SemanticRuleTest, sre.AbstractRuleTest);


### PR DESCRIPTION
* Introduces function contexts for single speech rules.
* Cleaner separation of custom functions in rules.
* Removes interactions between different rule sets via named custom functions
* Removes rule set restrictions in speech rule tests.