### PR TITLE
Updates wgxpath path for Edge/IE

### DIFF
--- a/src/common/variables.js
+++ b/src/common/variables.js
@@ -66,7 +66,7 @@ sre.Variables.url = 'https://cdn.jsdelivr.net/npm/speech-rule-engine@' +
  * @const
  * @type {string}
  */
-sre.Variables.WGXpath = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/' +
-    sre.Variables.mathjaxVersion + '/extensions/a11y/wgxpath.install.js';
+sre.Variables.WGXpath =
+  'https://cdn.jsdelivr.net/npm/mathjax@2/extensions/a11y/wgxpath.install.js';
 
 

--- a/src/common/variables.js
+++ b/src/common/variables.js
@@ -67,6 +67,6 @@ sre.Variables.url = 'https://cdn.jsdelivr.net/npm/speech-rule-engine@' +
  * @type {string}
  */
 sre.Variables.WGXpath =
-  'https://cdn.jsdelivr.net/npm/mathjax@2/extensions/a11y/wgxpath.install.js';
+  'https://cdn.jsdelivr.net/npm/wicked-good-xpath@1.3.0/dist/wgxpath.install.js';
 
 


### PR DESCRIPTION
Updates the path to always load the latest version of `wicked-good-xpath` from `jsdelivr`.

_Note, this is based on the `wicked-good-xpath` npm package and __NOT__ on the `wgxpath` package._