### PR TITLE
Changes makefile to avoid negative head parameter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ $(LOC_DST):
 			echo ','  >> $@; \
 		done; \
 	done
-	@head -n -1 $@ > $@.tmp
+	@sed '$$d' $@ > $@.tmp
 	@echo '}\n' >> $@.tmp
 	@mv $@.tmp $@
 


### PR DESCRIPTION
Replaces the use of `head -n -1` by `sed '$d'` in the Makefile for compatibility with non-GNU implementations of `head` (e.g., Mac OSX).

Solves issue #348 .