### PR TITLE
Issue 284

### DIFF
--- a/res/l10n/EnrichExamples.js
+++ b/res/l10n/EnrichExamples.js
@@ -473,4 +473,9 @@ Lab.Examples = ['<mrow><mrow><mi>a</mi></mrow></mrow><mrow><mi>b</mi></mrow>',
 '<msub><mrow><mo></mo><mo></mo><mo>|</mo></mrow><mi>t</mi></msub>',
 '<mo>=</mo><mo>&#x222B;</mo>',
 '<mo>&#x222B;</mo><mo>+</mo><mo>&#x222B;</mo>',
-'<mrow><mtext>-</mtext><mi mathvariant=\'normal\'>p</mi></mrow><mo>&#x2061;</mo><mi>&#x3C9;</mi>']
+'<mrow><mtext>-</mtext><mi mathvariant=\'normal\'>p</mi></mrow><mo>&#x2061;</mo><mi>&#x3C9;</mi>',
+'<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+'<mn>2</mn><mo>&#x2064;</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+'<mn>2</mn><mo>+</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+'<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac><mo>+</mo><mn>2</mn>',
+'<mn>a</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>']

--- a/res/l10n/de/ClearspeakGerman.html
+++ b/res/l10n/de/ClearspeakGerman.html
@@ -1275,16 +1275,27 @@
 <tr><td>0</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℝ</mi></math></td><td>the real numbers</td><td>die reellen Zahlen</td></tr>
 <tr><td>1</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">R</mi></math></td><td>the real numbers</td><td>die reellen Zahlen</td></tr>
 <tr><td>2</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℂ</mi></math></td><td>the complex numbers</td><td>die komplexen Zahlen</td></tr>
-<tr><td>3</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℤ</mi></math></td><td>the integers</td><td>die ganzen Zahlen</td></tr>
-<tr><td>4</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℚ</mi></math></td><td>the rational numbers</td><td>die rationalen Zahlen</td></tr>
-<tr><td>5</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℕ</mi></math></td><td>the natural numbers</td><td>die natürlichen Zahlen</td></tr>
-<tr><td>6</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>ℕ</mi><mn>0</mn></msub></math></td><td>the natural numbers with zero</td><td>die natürlichen Zahlen mit Null</td></tr>
-<tr><td>7</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>+</mo></msup></mrow></math></td><td>the positive integers</td><td>die positiven ganzen Zahlen</td></tr>
-<tr><td>8</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow></math></td><td>the negative integers</td><td>die negativen ganzen Zahlen</td></tr>
-<tr><td>9</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mn>2</mn></msup></mrow></math></td><td>r-two</td><td>r-zwei</td></tr>
-<tr><td>10</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow></math></td><td>z-three</td><td>z-drei</td></tr>
-<tr><td>11</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℂ</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td><td>c-n</td></tr>
-<tr><td>12</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow></math></td><td>r-infinity</td><td>r-unendlich</td></tr>
+<tr><td>3</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">C</mi></math></td><td>the complex numbers</td><td>die komplexen Zahlen</td></tr>
+<tr><td>4</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℤ</mi></math></td><td>the integers</td><td>die ganzen Zahlen</td></tr>
+<tr><td>5</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">Z</mi></math></td><td>the integers</td><td>die ganzen Zahlen</td></tr>
+<tr><td>6</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℚ</mi></math></td><td>the rational numbers</td><td>die rationalen Zahlen</td></tr>
+<tr><td>7</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">Q</mi></math></td><td>the rational numbers</td><td>die rationalen Zahlen</td></tr>
+<tr><td>8</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℕ</mi></math></td><td>the natural numbers</td><td>die natürlichen Zahlen</td></tr>
+<tr><td>9</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">N</mi></math></td><td>the natural numbers</td><td>die natürlichen Zahlen</td></tr>
+<tr><td>10</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>ℕ</mi><mn>0</mn></msub></math></td><td>the natural numbers with zero</td><td>die natürlichen Zahlen mit Null</td></tr>
+<tr><td>11</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="double-struck">N</mi><mn>0</mn></msub></math></td><td>the natural numbers with zero</td><td>die natürlichen Zahlen mit Null</td></tr>
+<tr><td>12</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>+</mo></msup></mrow></math></td><td>the positive integers</td><td>die positiven ganzen Zahlen</td></tr>
+<tr><td>13</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mo>+</mo></msup></mrow></math></td><td>the positive integers</td><td>die positiven ganzen Zahlen</td></tr>
+<tr><td>14</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow></math></td><td>the negative integers</td><td>die negativen ganzen Zahlen</td></tr>
+<tr><td>15</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mo>-</mo></msup></mrow></math></td><td>the negative integers</td><td>die negativen ganzen Zahlen</td></tr>
+<tr><td>16</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mn>2</mn></msup></mrow></math></td><td>r-two</td><td>r-zwei</td></tr>
+<tr><td>17</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">R</mi><mn>2</mn></msup></mrow></math></td><td>r-two</td><td>r-zwei</td></tr>
+<tr><td>18</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow></math></td><td>z-three</td><td>z-drei</td></tr>
+<tr><td>19</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mn>3</mn></msup></mrow></math></td><td>z-three</td><td>z-drei</td></tr>
+<tr><td>20</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℂ</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td><td>c-n</td></tr>
+<tr><td>21</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">C</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td><td>c-n</td></tr>
+<tr><td>22</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow></math></td><td>r-infinity</td><td>r-unendlich</td></tr>
+<tr><td>23</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">R</mi><mi>∞</mi></msup></mrow></math></td><td>r-infinity</td><td>r-unendlich</td></tr>
 </table>
 
 </body>

--- a/res/l10n/en/ClearspeakCharactersEnglish.html
+++ b/res/l10n/en/ClearspeakCharactersEnglish.html
@@ -3271,7 +3271,7 @@
 <tr><td>3255</td><td>^</td><td>hat</td></tr>
 <tr><td>3256</td><td>_</td><td>bar</td></tr>
 <tr><td>3257</td><td>`</td><td>grave</td></tr>
-<tr><td>3258</td><td>|</td><td>divides</td></tr>
+<tr><td>3258</td><td>|</td><td>vertical bar</td></tr>
 <tr><td>3259</td><td>~</td><td>tilde</td></tr>
 <tr><td>3260</td><td>¡</td><td>inverted exclamation mark</td></tr>
 <tr><td>3261</td><td>¢</td><td>cent sign</td></tr>
@@ -3423,7 +3423,7 @@
 <tr><td>3407</td><td>∠</td><td>angle</td></tr>
 <tr><td>3408</td><td>∡</td><td>measured angle</td></tr>
 <tr><td>3409</td><td>∢</td><td>spherical angle</td></tr>
-<tr><td>3410</td><td>∣</td><td>bar</td></tr>
+<tr><td>3410</td><td>∣</td><td>vertical bar</td></tr>
 <tr><td>3411</td><td>∤</td><td>does not divide</td></tr>
 <tr><td>3412</td><td>∥</td><td>parallel to</td></tr>
 <tr><td>3413</td><td>∦</td><td>not parallel to</td></tr>

--- a/res/l10n/en/ClearspeakEnglish.html
+++ b/res/l10n/en/ClearspeakEnglish.html
@@ -1250,16 +1250,27 @@
 <tr><td>0</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℝ</mi></math></td><td>the real numbers</td></tr>
 <tr><td>1</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">R</mi></math></td><td>the real numbers</td></tr>
 <tr><td>2</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℂ</mi></math></td><td>the complex numbers</td></tr>
-<tr><td>3</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℤ</mi></math></td><td>the integers</td></tr>
-<tr><td>4</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℚ</mi></math></td><td>the rational numbers</td></tr>
-<tr><td>5</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℕ</mi></math></td><td>the natural numbers</td></tr>
-<tr><td>6</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>ℕ</mi><mn>0</mn></msub></math></td><td>the natural numbers with zero</td></tr>
-<tr><td>7</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>+</mo></msup></mrow></math></td><td>the positive integers</td></tr>
-<tr><td>8</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow></math></td><td>the negative integers</td></tr>
-<tr><td>9</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mn>2</mn></msup></mrow></math></td><td>r-two</td></tr>
-<tr><td>10</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow></math></td><td>z-three</td></tr>
-<tr><td>11</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℂ</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td></tr>
-<tr><td>12</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow></math></td><td>r-infinity</td></tr>
+<tr><td>3</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">C</mi></math></td><td>the complex numbers</td></tr>
+<tr><td>4</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℤ</mi></math></td><td>the integers</td></tr>
+<tr><td>5</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">Z</mi></math></td><td>the integers</td></tr>
+<tr><td>6</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℚ</mi></math></td><td>the rational numbers</td></tr>
+<tr><td>7</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">Q</mi></math></td><td>the rational numbers</td></tr>
+<tr><td>8</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℕ</mi></math></td><td>the natural numbers</td></tr>
+<tr><td>9</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">N</mi></math></td><td>the natural numbers</td></tr>
+<tr><td>10</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>ℕ</mi><mn>0</mn></msub></math></td><td>the natural numbers with zero</td></tr>
+<tr><td>11</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="double-struck">N</mi><mn>0</mn></msub></math></td><td>the natural numbers with zero</td></tr>
+<tr><td>12</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>+</mo></msup></mrow></math></td><td>the positive integers</td></tr>
+<tr><td>13</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mo>+</mo></msup></mrow></math></td><td>the positive integers</td></tr>
+<tr><td>14</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow></math></td><td>the negative integers</td></tr>
+<tr><td>15</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mo>-</mo></msup></mrow></math></td><td>the negative integers</td></tr>
+<tr><td>16</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mn>2</mn></msup></mrow></math></td><td>r-two</td></tr>
+<tr><td>17</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">R</mi><mn>2</mn></msup></mrow></math></td><td>r-two</td></tr>
+<tr><td>18</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow></math></td><td>z-three</td></tr>
+<tr><td>19</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mn>3</mn></msup></mrow></math></td><td>z-three</td></tr>
+<tr><td>20</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℂ</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td></tr>
+<tr><td>21</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">C</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td></tr>
+<tr><td>22</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow></math></td><td>r-infinity</td></tr>
+<tr><td>23</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">R</mi><mi>∞</mi></msup></mrow></math></td><td>r-infinity</td></tr>
 </table>
 
 </body>

--- a/res/l10n/en/DefaultCharactersEnglish.html
+++ b/res/l10n/en/DefaultCharactersEnglish.html
@@ -3416,7 +3416,7 @@
 <tr><td>3400</td><td>∠</td><td>angle</td></tr>
 <tr><td>3401</td><td>∡</td><td>measured angle</td></tr>
 <tr><td>3402</td><td>∢</td><td>spherical angle</td></tr>
-<tr><td>3403</td><td>∣</td><td>bar</td></tr>
+<tr><td>3403</td><td>∣</td><td>vertical bar</td></tr>
 <tr><td>3404</td><td>∤</td><td>does not divide</td></tr>
 <tr><td>3405</td><td>∥</td><td>parallel to</td></tr>
 <tr><td>3406</td><td>∦</td><td>not parallel to</td></tr>

--- a/res/l10n/en/MathspeakCharactersEnglish.html
+++ b/res/l10n/en/MathspeakCharactersEnglish.html
@@ -3424,7 +3424,7 @@
 <tr><td>3408</td><td>∠</td><td>angle</td></tr>
 <tr><td>3409</td><td>∡</td><td>measured angle</td></tr>
 <tr><td>3410</td><td>∢</td><td>spherical angle</td></tr>
-<tr><td>3411</td><td>∣</td><td>bar</td></tr>
+<tr><td>3411</td><td>∣</td><td>vertical bar</td></tr>
 <tr><td>3412</td><td>∤</td><td>does not divide</td></tr>
 <tr><td>3413</td><td>∥</td><td>parallel to</td></tr>
 <tr><td>3414</td><td>∦</td><td>not parallel to</td></tr>
@@ -7776,7 +7776,7 @@
 <tr><td>3408</td><td>∠</td><td>angle</td></tr>
 <tr><td>3409</td><td>∡</td><td>measured angle</td></tr>
 <tr><td>3410</td><td>∢</td><td>spherical angle</td></tr>
-<tr><td>3411</td><td>∣</td><td>bar</td></tr>
+<tr><td>3411</td><td>∣</td><td>vertical bar</td></tr>
 <tr><td>3412</td><td>∤</td><td>does not divide</td></tr>
 <tr><td>3413</td><td>∥</td><td>parallel to</td></tr>
 <tr><td>3414</td><td>∦</td><td>not parallel to</td></tr>
@@ -12128,7 +12128,7 @@
 <tr><td>3408</td><td>∠</td><td>angle</td></tr>
 <tr><td>3409</td><td>∡</td><td>measured angle</td></tr>
 <tr><td>3410</td><td>∢</td><td>spherical angle</td></tr>
-<tr><td>3411</td><td>∣</td><td>bar</td></tr>
+<tr><td>3411</td><td>∣</td><td>vertical bar</td></tr>
 <tr><td>3412</td><td>∤</td><td>does not divide</td></tr>
 <tr><td>3413</td><td>∥</td><td>parallel to</td></tr>
 <tr><td>3414</td><td>∦</td><td>not parallel to</td></tr>

--- a/res/l10n/fr/ClearspeakFrench.html
+++ b/res/l10n/fr/ClearspeakFrench.html
@@ -1231,16 +1231,27 @@
 <tr><td>0</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℝ</mi></math></td><td>les nombres réels</td></tr>
 <tr><td>1</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">R</mi></math></td><td>les nombres réels</td></tr>
 <tr><td>2</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℂ</mi></math></td><td>les nombres complexes</td></tr>
-<tr><td>3</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℤ</mi></math></td><td>les nombres entiers</td></tr>
-<tr><td>4</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℚ</mi></math></td><td>les Nombres rationnels</td></tr>
-<tr><td>5</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℕ</mi></math></td><td>les nombres entier naturel</td></tr>
-<tr><td>6</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>ℕ</mi><mn>0</mn></msub></math></td><td>les nombres entiers naturel avec zero</td></tr>
-<tr><td>7</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>+</mo></msup></mrow></math></td><td>les nombres entiers positif</td></tr>
-<tr><td>8</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow></math></td><td>les nombres entiers négatif</td></tr>
-<tr><td>9</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mn>2</mn></msup></mrow></math></td><td>r-deux</td></tr>
-<tr><td>10</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow></math></td><td>z-trois</td></tr>
-<tr><td>11</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℂ</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td></tr>
-<tr><td>12</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow></math></td><td>r-infini</td></tr>
+<tr><td>3</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">C</mi></math></td><td>les nombres complexes</td></tr>
+<tr><td>4</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℤ</mi></math></td><td>les nombres entiers</td></tr>
+<tr><td>5</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">Z</mi></math></td><td>les nombres entiers</td></tr>
+<tr><td>6</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℚ</mi></math></td><td>les Nombres rationnels</td></tr>
+<tr><td>7</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">Q</mi></math></td><td>les Nombres rationnels</td></tr>
+<tr><td>8</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>ℕ</mi></math></td><td>les nombres entier naturel</td></tr>
+<tr><td>9</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mi mathvariant="double-struck">N</mi></math></td><td>les nombres entier naturel</td></tr>
+<tr><td>10</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>ℕ</mi><mn>0</mn></msub></math></td><td>les nombres entiers naturel avec zero</td></tr>
+<tr><td>11</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi mathvariant="double-struck">N</mi><mn>0</mn></msub></math></td><td>les nombres entiers naturel avec zero</td></tr>
+<tr><td>12</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>+</mo></msup></mrow></math></td><td>les nombres entiers positif</td></tr>
+<tr><td>13</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mo>+</mo></msup></mrow></math></td><td>les nombres entiers positif</td></tr>
+<tr><td>14</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow></math></td><td>les nombres entiers négatif</td></tr>
+<tr><td>15</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mo>-</mo></msup></mrow></math></td><td>les nombres entiers négatif</td></tr>
+<tr><td>16</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mn>2</mn></msup></mrow></math></td><td>r-deux</td></tr>
+<tr><td>17</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">R</mi><mn>2</mn></msup></mrow></math></td><td>r-deux</td></tr>
+<tr><td>18</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow></math></td><td>z-trois</td></tr>
+<tr><td>19</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">Z</mi><mn>3</mn></msup></mrow></math></td><td>z-trois</td></tr>
+<tr><td>20</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℂ</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td></tr>
+<tr><td>21</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">C</mi><mi>n</mi></msup></mrow></math></td><td>c-n</td></tr>
+<tr><td>22</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow></math></td><td>r-infini</td></tr>
+<tr><td>23</td><td><math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><msup><mi mathvariant="double-struck">R</mi><mi>∞</mi></msup></mrow></math></td><td>r-infini</td></tr>
 </table>
 
 </body>

--- a/res/l10n/nemeth/DefaultCharactersNemeth.html
+++ b/res/l10n/nemeth/DefaultCharactersNemeth.html
@@ -3416,7 +3416,7 @@
 <tr><td>3400</td><td>∠</td><td>angle</td><td>⠫⠪</td></tr>
 <tr><td>3401</td><td>∡</td><td>measured angle</td><td>⠫⠪⠸⠫⠫⠁⠻</td></tr>
 <tr><td>3402</td><td>∢</td><td>spherical angle</td><td>⠫⠪⠸⠫⠫⠁⠻</td></tr>
-<tr><td>3403</td><td>∣</td><td>bar</td><td>⠳</td></tr>
+<tr><td>3403</td><td>∣</td><td>vertical bar</td><td>⠳</td></tr>
 <tr><td>3404</td><td>∤</td><td>does not divide</td><td>⠌⠳</td></tr>
 <tr><td>3405</td><td>∥</td><td>parallel to</td><td>⠀⠫⠇⠀</td></tr>
 <tr><td>3406</td><td>∦</td><td>not parallel to</td><td>⠀⠌⠫⠇⠀</td></tr>

--- a/src/mathmaps/en/symbols/math_symbols.js
+++ b/src/mathmaps/en/symbols/math_symbols.js
@@ -245,9 +245,6 @@
     "mappings": {
       "default": {
         "default": "vertical bar"
-      },
-      "clearspeak": {
-        "default": "divides"
       }
     },
     "key": "007C"
@@ -1652,11 +1649,8 @@
     "category": "Sm",
     "mappings": {
       "default": {
-        "default": "bar",
+        "default": "vertical bar",
         "alternative": "divides"
-      },
-      "clearspeak": {
-        "default": "divides"
       }
     },
     "key": "2223"

--- a/src/mathmaps/en/symbols/math_symbols.js
+++ b/src/mathmaps/en/symbols/math_symbols.js
@@ -1654,6 +1654,9 @@
       "default": {
         "default": "bar",
         "alternative": "divides"
+      },
+      "clearspeak": {
+        "default": "divides"
       }
     },
     "key": "2223"

--- a/src/semantic_tree/semantic_attr.js
+++ b/src/semantic_tree/semantic_attr.js
@@ -1550,7 +1550,7 @@ sre.SemanticAttr.Role = {
   LATINLETTER: 'latinletter',
   GREEKLETTER: 'greekletter',
   OTHERLETTER: 'otherletter',
-  NUMBERSET: 'numberset',
+  NUMBERSET: 'numbersetletter',
 
   // Numbers.
   INTEGER: 'integer',

--- a/src/semantic_tree/semantic_attr.js
+++ b/src/semantic_tree/semantic_attr.js
@@ -1550,6 +1550,7 @@ sre.SemanticAttr.Role = {
   LATINLETTER: 'latinletter',
   GREEKLETTER: 'greekletter',
   OTHERLETTER: 'otherletter',
+  NUMBERSET: 'numberset',
 
   // Numbers.
   INTEGER: 'integer',

--- a/src/semantic_tree/semantic_attr.js
+++ b/src/semantic_tree/semantic_attr.js
@@ -198,7 +198,7 @@ sre.SemanticAttr = function() {
    */
   this.neutralFences =
       [
-        '|', '¦', '‖', '❘', '⦀', '⫴', '￤', '｜'
+        '|', '¦', '‖', '❘', '⦀', '⫴', '￤', '｜', '∣'
       ];
   /** Array of all fences.
    * @type {Array.<string>}

--- a/src/semantic_tree/semantic_attr.js
+++ b/src/semantic_tree/semantic_attr.js
@@ -1750,6 +1750,15 @@ sre.SemanticAttr.invisibleTimes = function() {
 
 
 /**
+ * String representation of the invisible plus unicode character.
+ * @return {string} The invisible plus character.
+ */
+sre.SemanticAttr.invisiblePlus = function() {
+  return sre.SemanticAttr.getInstance().invisiblePlus_;
+};
+
+
+/**
  * String representation of the invisible comma unicode character.
  * @return {string} The invisible comma character.
  */

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -73,6 +73,16 @@ sre.SemanticMathml = function() {
     'MACTION': goog.bind(this.action_, this)
   };
 
+  let meaning = {
+    type: sre.SemanticAttr.Type.IDENTIFIER,
+    role: sre.SemanticAttr.Role.NUMBERSET,
+    font: sre.SemanticAttr.Font.DOUBLESTRUCK
+  };
+  ['C', 'H', 'N', 'P', 'Q', 'R', 'Z', 'ℂ', 'ℍ', 'ℕ', 'ℙ', 'ℚ', 'ℝ', 'ℤ'].
+    forEach(function(x) {
+     this.getFactory().defaultMap.add(x, meaning);
+    }.bind(this));
+
 };
 goog.inherits(sre.SemanticMathml, sre.SemanticAbstractParser);
 

--- a/src/speech_rules/de/clearspeak_german.js
+++ b/src/speech_rules/de/clearspeak_german.js
@@ -1545,31 +1545,31 @@ sre.ClearspeakGerman = {
       'natural-numbers-super', 'default',
       '[t] "n" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
       'self::superscript', 'children/*[1]/text()="\u2115"' +
-     ' or (children/*[1]/text()="N" and @font="double-struck")',
+     ' or (children/*[1]/text()="N" and children/*[1]/@font="double-struck")',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'integers-super', 'default',
       '[t] "z" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
       'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'rational-numbers-super', 'default',
       '[t] "q" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
       'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'real-numbers-super', 'default',
       '[t] "r" (join:"-"); [n] children/*[2] (grammar:numbers2alpha)',
       'self::superscript', 'children/*[1]/text()="\u211D"' +
-     ' or (children/*[1]/text()="R" and @font="double-struck")',
+     ' or (children/*[1]/text()="R" and children/*[1]/@font="double-struck")',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'complex-numbers-super', 'default',
       '[t] "c" (join:"-"); [n] children/*[2] (grammar:numbers2alpha)',
       'self::superscript', 'children/*[1]/text()="\u2102"' +
-     ' or (children/*[1]/text()="C" and @font="double-struck")',
+     ' or (children/*[1]/text()="C" and children/*[1]/@font="double-struck")',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
 
     // Partial named sets.
@@ -1577,35 +1577,35 @@ sre.ClearspeakGerman = {
       'natural-numbers-with-zero', 'default',
       '[t] "die natürlichen Zahlen mit Null"',
       'self::subscript', 'children/*[1]/text()="\u2115"' +
-     ' or (children/*[1]/text()="N" and @font="double-struck")',
+     ' or (children/*[1]/text()="N" and children/*[1]/@font="double-struck")',
       'children/*[2]/text()="0"',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'positive-integers', 'default',
       '[t] "die positiven ganzen Zahlen"',
       'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
       'children/*[2]/text()="+"',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'positive-integers', 'default',
       '[t] "die negativen ganzen Zahlen"',
       'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
       'children/*[2]/text()="-"',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'positive-rational-numbers', 'default',
       '[t] "die positiven rationalen Zahlen"',
       'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
       'children/*[2]/text()="+"',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     ['Rule',
       'negative-rational-numbers', 'default',
       '[t] "die negativen rationalen Zahlen"',
       'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
       'children/*[2]/text()="-"',
       'self::*', 'self::*', 'self::*', 'self::*', 'self::*'],
     // TODO: Do we need positive and negative real numbers. Usually they are

--- a/src/speech_rules/en/clearspeak_rules.js
+++ b/src/speech_rules/en/clearspeak_rules.js
@@ -1506,31 +1506,31 @@ sre.ClearspeakRules = {
      'natural-numbers-super', 'default',
      '[t] "n" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u2115"' +
-     ' or (children/*[1]/text()="N" and @font="double-struck")',
+     ' or (children/*[1]/text()="N" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'integers-super', 'default',
      '[t] "z" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'rational-numbers-super', 'default',
      '[t] "q" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'real-numbers-super', 'default',
      '[t] "r" (join:"-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u211D"' +
-     ' or (children/*[1]/text()="R" and @font="double-struck")',
+     ' or (children/*[1]/text()="R" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'complex-numbers-super', 'default',
      '[t] "c" (join:"-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u2102"' +
-     ' or (children/*[1]/text()="C" and @font="double-struck")',
+     ' or (children/*[1]/text()="C" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
 
     // Partial named sets.
@@ -1538,34 +1538,34 @@ sre.ClearspeakRules = {
      'natural-numbers-with-zero', 'default',
      '[t] "the natural numbers with zero"',
      'self::subscript', 'children/*[1]/text()="\u2115"' +
-     ' or (children/*[1]/text()="N" and @font="double-struck")',
+     ' or (children/*[1]/text()="N" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="0"'],
     ['Rule',
      'positive-integers', 'default',
      '[t] "the positive integers"',
      'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="+"',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'positive-integers', 'default',
      '[t] "the negative integers"',
      'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="-"',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'positive-rational-numbers', 'default',
      '[t] "the positive rational numbers"',
      'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="+"',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'negative-rational-numbers', 'default',
      '[t] "the negative rational numbers"',
      'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="-"',
      'self::*', 'self::*', 'self::*'],
     // TODO: Do we need positive and negative real numbers. Usually they are

--- a/src/speech_rules/en/clearspeak_rules.js
+++ b/src/speech_rules/en/clearspeak_rules.js
@@ -216,12 +216,18 @@ sre.ClearspeakRules = {
      'not(parent::*/parent::*[@embellished="punctuation"])'
     ],
     ['Rule',
-     'vbar-such-that', 'VerticalLine_Divides',
+     'vbar-divides', 'default',
+     '[t] "divides"', 'self::punctuation', '@role="vbar"',
+     'not(parent::*/parent::*[@embellished="punctuation"])',
+     'parent::*/parent::*[@role="sequence"]'
+    ],
+    ['Rule',
+     'vbar-divides', 'VerticalLine_Divides',
      '[t] "divides"', 'self::punctuation', '@role="vbar"',
      'not(parent::*/parent::*[@embellished="punctuation"])'
     ],
     ['Rule',
-     'vbar-such-that', 'VerticalLine_Given',
+     'vbar-given', 'VerticalLine_Given',
      '[t] "given"', 'self::punctuation', '@role="vbar"',
      'not(parent::*/parent::*[@embellished="punctuation"])'
     ],

--- a/src/speech_rules/fr/clearspeak_french.js
+++ b/src/speech_rules/fr/clearspeak_french.js
@@ -1428,31 +1428,31 @@ sre.ClearspeakFrench = {
      'natural-numbers-super', 'default',
      '[t] "n" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u2115"' +
-     ' or (children/*[1]/text()="N" and @font="double-struck")',
+     ' or (children/*[1]/text()="N" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'integers-super', 'default',
      '[t] "z" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'rational-numbers-super', 'default',
      '[t] "q" (join: "-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'real-numbers-super', 'default',
      '[t] "r" (join:"-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u211D"' +
-     ' or (children/*[1]/text()="R" and @font="double-struck")',
+     ' or (children/*[1]/text()="R" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'complex-numbers-super', 'default',
      '[t] "c" (join:"-"); [n] children/*[2] (grammar:numbers2alpha)',
      'self::superscript', 'children/*[1]/text()="\u2102"' +
-     ' or (children/*[1]/text()="C" and @font="double-struck")',
+     ' or (children/*[1]/text()="C" and children/*[1]/@font="double-struck")',
      'self::*', 'self::*', 'self::*'],
 
     // Partial named sets.
@@ -1460,34 +1460,34 @@ sre.ClearspeakFrench = {
      'natural-numbers-with-zero', 'default',
      '[t] "les nombres entiers naturel avec zero"',
      'self::subscript', 'children/*[1]/text()="\u2115"' +
-     ' or (children/*[1]/text()="N" and @font="double-struck")',
+     ' or (children/*[1]/text()="N" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="0"'],
     ['Rule',
      'positive-integers', 'default',
      '[t] "les nombres entiers positif"',
      'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="+"',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'positive-integers', 'default',
      '[t] "les nombres entiers négatif"',
      'self::superscript', 'children/*[1]/text()="\u2124"' +
-     ' or (children/*[1]/text()="Z" and @font="double-struck")',
+     ' or (children/*[1]/text()="Z" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="-"',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'positive-rational-numbers', 'default',
      '[t] "les nombres rationnels positif"',
      'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="+"',
      'self::*', 'self::*', 'self::*'],
     ['Rule',
      'negative-rational-numbers', 'default',
      '[t] "les nombres rationnels négatif"',
      'self::superscript', 'children/*[1]/text()="\u211A"' +
-     ' or (children/*[1]/text()="Q" and @font="double-struck")',
+     ' or (children/*[1]/text()="Q" and children/*[1]/@font="double-struck")',
      'children/*[2]/text()="-"',
      'self::*', 'self::*', 'self::*'],
     // TODO: Do we need positive and negative real numbers. Usually they are

--- a/src/speech_rules/nemeth/nemeth_rules.js
+++ b/src/speech_rules/nemeth/nemeth_rules.js
@@ -802,7 +802,7 @@ sre.NemethRules = {
     ['Rule',
      'punctuation-comma', 'default', '[n] text(); [t] "⠀"',
      'self::punctuation' , 'parent::*/parent::punctuated',
-     'following-sibling::*', '@role!="fullstop"',
+     'following-sibling::*', '@role!="fullstop"', '@role!="vbar"'
     ],
 
     ['Rule',

--- a/tests/base/enrich_mathml_test.js
+++ b/tests/base/enrich_mathml_test.js
@@ -11326,3 +11326,26 @@ sre.EnrichMathmlTest.prototype.testIssue383 = function() {
     '<math type="appl" role="simple function" id="7" children="3,5" content="6"><mrow type="punctuated" role="simple function" id="3" children="0,1" parent="7" collapsed="(3 (c 2) 0 1)"><mtext type="text" role="simple function" id="0" parent="3">-</mtext><mi mathvariant="normal" type="identifier" role="latinletter" id="1" parent="3">p</mi></mrow><mo type="punctuation" role="application" id="6" parent="7" added="true" operator="appl">⁡</mo><mi type="identifier" role="greekletter" id="5" parent="7">ω</mi></math>'
   );
 };
+
+
+/**
+ * Issue 284: Explicitly given invisible plus.
+ */
+sre.EnrichMathmlTest.prototype.testIssue284 = function() {
+  this.executeMathmlTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<math type="number" role="mixed" id="5" children="0,4"><mn type="number" role="integer" id="0" parent="5">2</mn><mo>⁤</mo><mfrac type="fraction" role="division" id="4" children="2,3" parent="5"><mn type="number" role="integer" id="2" parent="4">3</mn><mi type="identifier" role="latinletter" id="3" parent="4">p</mi></mfrac></math>');
+  this.executeMathmlTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<math type="infixop" role="addition" id="8" children="0,7" content="1"><mn type="number" role="integer" id="0" parent="8">2</mn><mo type="operator" role="addition" id="1" parent="8" operator="infixop,⁤">⁤</mo><mrow type="number" role="mixed" id="7" children="2,6" parent="8"><mn type="number" role="integer" id="2" parent="7">2</mn><mo>⁤</mo><mfrac type="fraction" role="division" id="6" children="4,5" parent="7"><mn type="number" role="integer" id="4" parent="6">3</mn><mi type="identifier" role="latinletter" id="5" parent="6">p</mi></mfrac></mrow></math>');
+  this.executeMathmlTest(
+    '<mn>2</mn><mo>+</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<math type="infixop" role="addition" id="8" children="0,7" content="1"><mn type="number" role="integer" id="0" parent="8">2</mn><mo type="operator" role="addition" id="1" parent="8" operator="infixop,+">+</mo><mrow type="number" role="mixed" id="7" children="2,6" parent="8"><mn type="number" role="integer" id="2" parent="7">2</mn><mo>⁤</mo><mfrac type="fraction" role="division" id="6" children="4,5" parent="7"><mn type="number" role="integer" id="4" parent="6">3</mn><mi type="identifier" role="latinletter" id="5" parent="6">p</mi></mfrac></mrow></math>');
+  this.executeMathmlTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac><mo>+</mo><mn>2</mn>',
+    '<math type="infixop" role="addition" id="8" children="7,6" content="5"><mrow type="number" role="mixed" id="7" children="0,4" parent="8"><mn type="number" role="integer" id="0" parent="7">2</mn><mo>⁤</mo><mfrac type="fraction" role="division" id="4" children="2,3" parent="7"><mn type="number" role="integer" id="2" parent="4">3</mn><mi type="identifier" role="latinletter" id="3" parent="4">p</mi></mfrac></mrow><mo type="operator" role="addition" id="5" parent="8" operator="infixop,+">+</mo><mn type="number" role="integer" id="6" parent="8">2</mn></math>');
+  this.executeMathmlTest(
+    '<mn>a</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<math type="number" role="mixed" id="5" children="0,4"><mn type="number" role="latinletter" id="0" parent="5">a</mn><mo>⁤</mo><mfrac type="fraction" role="division" id="4" children="2,3" parent="5"><mn type="number" role="integer" id="2" parent="4">3</mn><mi type="identifier" role="latinletter" id="3" parent="4">p</mi></mfrac></math>'
+  );
+};

--- a/tests/base/rebuild_stree_test.js
+++ b/tests/base/rebuild_stree_test.js
@@ -2305,3 +2305,20 @@ sre.RebuildStreeTest.prototype.testIssue383 = function() {
     '<mrow><mtext>-</mtext><mi mathvariant="normal">p</mi>' +
       '</mrow><mo>&#x2061;</mo><mi>&#x3C9;</mi>');
 };
+
+
+/**
+ * Issue 284: Explicitly given invisible plus.
+ */
+sre.RebuildStreeTest.prototype.testIssue284 = function() {
+  this.executeRebuildTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>');
+  this.executeRebuildTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>');
+  this.executeRebuildTest(
+    '<mn>2</mn><mo>+</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>');
+  this.executeRebuildTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac><mo>+</mo><mn>2</mn>');
+  this.executeRebuildTest(
+    '<mn>a</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>');
+};

--- a/tests/base/semantic_tree_test.js
+++ b/tests/base/semantic_tree_test.js
@@ -13036,3 +13036,30 @@ sre.SemanticTreeTest.prototype.testIssue383 = function() {
       '</children></appl>'
   );
 };
+
+
+/**
+ * Issue 284: Explicitly given invisible plus.
+ */
+sre.SemanticTreeTest.prototype.testIssue284 = function() {
+  this.executeTreeTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<number role="mixed" id="5"><children><number role="integer" font="normal" id="0">2</number><fraction role="division" id="4"><children><number role="integer" font="normal" id="2">3</number><identifier role="latinletter" font="italic" id="3">p</identifier></children></fraction></children></number>'
+  );
+  this.executeTreeTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<infixop role="addition" id="8">⁤<content><operator role="addition" id="1">⁤</operator></content><children><number role="integer" font="normal" id="0">2</number><number role="mixed" id="7"><children><number role="integer" font="normal" id="2">2</number><fraction role="division" id="6"><children><number role="integer" font="normal" id="4">3</number><identifier role="latinletter" font="italic" id="5">p</identifier></children></fraction></children></number></children></infixop>'
+  );
+  this.executeTreeTest(
+    '<mn>2</mn><mo>+</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<infixop role="addition" id="8">+<content><operator role="addition" id="1">+</operator></content><children><number role="integer" font="normal" id="0">2</number><number role="mixed" id="7"><children><number role="integer" font="normal" id="2">2</number><fraction role="division" id="6"><children><number role="integer" font="normal" id="4">3</number><identifier role="latinletter" font="italic" id="5">p</identifier></children></fraction></children></number></children></infixop>'
+  );
+  this.executeTreeTest(
+    '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac><mo>+</mo><mn>2</mn>',
+    '<infixop role="addition" id="8">+<content><operator role="addition" id="5">+</operator></content><children><number role="mixed" id="7"><children><number role="integer" font="normal" id="0">2</number><fraction role="division" id="4"><children><number role="integer" font="normal" id="2">3</number><identifier role="latinletter" font="italic" id="3">p</identifier></children></fraction></children></number><number role="integer" font="normal" id="6">2</number></children></infixop>'
+  );
+  this.executeTreeTest(
+    '<mn>a</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+    '<number role="mixed" id="5"><children><number role="latinletter" font="normal" id="0">a</number><fraction role="division" id="4"><children><number role="integer" font="normal" id="2">3</number><identifier role="latinletter" font="italic" id="3">p</identifier></children></fraction></children></number>'
+  );
+};

--- a/tests/de/clearspeak_german_named_sets.js
+++ b/tests/de/clearspeak_german_named_sets.js
@@ -84,11 +84,33 @@ sre.ClearspeakGermanNamedSets.prototype.testNumSys002 = function() {
 
 
 /**
+ * Testing ClearspeakGermanNamedSets Example NumSys002a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys002a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">C</mi>';
+  var speech = 'die komplexen Zahlen';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakGermanNamedSets Example NumSys003
  */
 sre.ClearspeakGermanNamedSets.prototype.testNumSys003 = function() {
   var preference = 'default';
   var mathml = '<mi>ℤ</mi>';
+  var speech = 'die ganzen Zahlen';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys003a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys003a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">Z</mi>';
   var speech = 'die ganzen Zahlen';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -106,6 +128,17 @@ sre.ClearspeakGermanNamedSets.prototype.testNumSys004 = function() {
 
 
 /**
+ * Testing ClearspeakGermanNamedSets Example NumSys004a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys004a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">Q</mi>';
+  var speech = 'die rationalen Zahlen';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakGermanNamedSets Example NumSys005
  */
 sre.ClearspeakGermanNamedSets.prototype.testNumSys005 = function() {
@@ -117,11 +150,33 @@ sre.ClearspeakGermanNamedSets.prototype.testNumSys005 = function() {
 
 
 /**
- * Testing ClearspeakGermanNamedSets Example NumSys005
+ * Testing ClearspeakGermanNamedSets Example NumSys005a
  */
 sre.ClearspeakGermanNamedSets.prototype.testNumSys005a = function() {
   var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">N</mi>';
+  var speech = 'die natürlichen Zahlen';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys005
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys005_1 = function() {
+  var preference = 'default';
   var mathml = '<msub><mi>ℕ</mi><mn>0</mn></msub>';
+  var speech = 'die natürlichen Zahlen mit Null';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys005a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys005_1a = function() {
+  var preference = 'default';
+  var mathml = '<msub><mi mathvariant="double-struck">N</mi><mn>0</mn></msub>';
   var speech = 'die natürlichen Zahlen mit Null';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -139,11 +194,33 @@ sre.ClearspeakGermanNamedSets.prototype.testNumSys006 = function() {
 
 
 /**
- * Testing ClearspeakGermanNamedSets Example NumSys006
+ * Testing ClearspeakGermanNamedSets Example NumSys006a
  */
 sre.ClearspeakGermanNamedSets.prototype.testNumSys006a = function() {
   var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mo>+</mo></msup></mrow>';
+  var speech = 'die positiven ganzen Zahlen';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys006
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys006_1 = function() {
+  var preference = 'default';
   var mathml = '<mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow>';
+  var speech = 'die negativen ganzen Zahlen';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys006a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys006_1a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mo>-</mo></msup></mrow>';
   var speech = 'die negativen ganzen Zahlen';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -161,11 +238,33 @@ sre.ClearspeakGermanNamedSets.prototype.testNumSys007 = function() {
 
 
 /**
+ * Testing ClearspeakGermanNamedSets Example NumSys007a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys007a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">R</mi><mn>2</mn></msup></mrow>';
+  var speech = 'r-zwei';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakGermanNamedSets Example NumSys008
  */
 sre.ClearspeakGermanNamedSets.prototype.testNumSys008 = function() {
   var preference = 'default';
   var mathml = '<mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow>';
+  var speech = 'z-drei';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys008a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys008a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mn>3</mn></msup></mrow>';
   var speech = 'z-drei';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -183,11 +282,33 @@ sre.ClearspeakGermanNamedSets.prototype.testNumSys009 = function() {
 
 
 /**
+ * Testing ClearspeakGermanNamedSets Example NumSys009a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys009a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">C</mi><mi>n</mi></msup></mrow>';
+  var speech = 'c-n';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakGermanNamedSets Example NumSys010
  */
 sre.ClearspeakGermanNamedSets.prototype.testNumSys010 = function() {
   var preference = 'default';
   var mathml = '<mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow>';
+  var speech = 'r-unendlich';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakGermanNamedSets Example NumSys010a
+ */
+sre.ClearspeakGermanNamedSets.prototype.testNumSys010a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">R</mi><mi>∞</mi></msup></mrow>';
   var speech = 'r-unendlich';
   this.executeRuleTest(mathml, speech, preference);
 };

--- a/tests/en/clearspeak_char_english_test.js
+++ b/tests/en/clearspeak_char_english_test.js
@@ -3305,7 +3305,7 @@ sre.ClearspeakCharEnglishTest.prototype.testClearspeakChars = function() {
   this.executeCharTest('^', ['hat']);
   this.executeCharTest('_', ['bar']);
   this.executeCharTest('`', ['grave']);
-  this.executeCharTest('|', ['divides']);
+  this.executeCharTest('|', ['vertical bar']);
   this.executeCharTest('~', ['tilde']);
   this.executeCharTest('¡', ['inverted exclamation mark']);
   this.executeCharTest('¢', ['cent sign']);
@@ -3457,7 +3457,7 @@ sre.ClearspeakCharEnglishTest.prototype.testClearspeakChars = function() {
   this.executeCharTest('∠', ['angle']);
   this.executeCharTest('∡', ['measured angle']);
   this.executeCharTest('∢', ['spherical angle']);
-  this.executeCharTest('∣', ['bar']);
+  this.executeCharTest('∣', ['vertical bar']);
   this.executeCharTest('∤', ['does not divide']);
   this.executeCharTest('∥', ['parallel to']);
   this.executeCharTest('∦', ['not parallel to']);

--- a/tests/en/clearspeak_english_named_sets.js
+++ b/tests/en/clearspeak_english_named_sets.js
@@ -84,11 +84,33 @@ sre.ClearspeakEnglishNamedSets.prototype.testNumSys002 = function() {
 
 
 /**
+ * Testing ClearspeakEnglishNamedSets Example NumSys002a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys002a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">C</mi>';
+  var speech = 'the complex numbers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakEnglishNamedSets Example NumSys003
  */
 sre.ClearspeakEnglishNamedSets.prototype.testNumSys003 = function() {
   var preference = 'default';
   var mathml = '<mi>ℤ</mi>';
+  var speech = 'the integers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys003a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys003a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">Z</mi>';
   var speech = 'the integers';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -106,6 +128,17 @@ sre.ClearspeakEnglishNamedSets.prototype.testNumSys004 = function() {
 
 
 /**
+ * Testing ClearspeakEnglishNamedSets Example NumSys004a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys004a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">Q</mi>';
+  var speech = 'the rational numbers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakEnglishNamedSets Example NumSys005
  */
 sre.ClearspeakEnglishNamedSets.prototype.testNumSys005 = function() {
@@ -117,11 +150,33 @@ sre.ClearspeakEnglishNamedSets.prototype.testNumSys005 = function() {
 
 
 /**
- * Testing ClearspeakEnglishNamedSets Example NumSys005
+ * Testing ClearspeakEnglishNamedSets Example NumSys005a
  */
 sre.ClearspeakEnglishNamedSets.prototype.testNumSys005a = function() {
   var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">N</mi>';
+  var speech = 'the natural numbers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys005
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys005_1 = function() {
+  var preference = 'default';
   var mathml = '<msub><mi>ℕ</mi><mn>0</mn></msub>';
+  var speech = 'the natural numbers with zero';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys005a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys005_1a = function() {
+  var preference = 'default';
+  var mathml = '<msub><mi mathvariant="double-struck">N</mi><mn>0</mn></msub>';
   var speech = 'the natural numbers with zero';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -139,11 +194,33 @@ sre.ClearspeakEnglishNamedSets.prototype.testNumSys006 = function() {
 
 
 /**
- * Testing ClearspeakEnglishNamedSets Example NumSys006
+ * Testing ClearspeakEnglishNamedSets Example NumSys006a
  */
 sre.ClearspeakEnglishNamedSets.prototype.testNumSys006a = function() {
   var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mo>+</mo></msup></mrow>';
+  var speech = 'the positive integers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys006
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys006_1 = function() {
+  var preference = 'default';
   var mathml = '<mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow>';
+  var speech = 'the negative integers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys006a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys006_1a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mo>-</mo></msup></mrow>';
   var speech = 'the negative integers';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -161,11 +238,33 @@ sre.ClearspeakEnglishNamedSets.prototype.testNumSys007 = function() {
 
 
 /**
+ * Testing ClearspeakEnglishNamedSets Example NumSys007a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys007a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">R</mi><mn>2</mn></msup></mrow>';
+  var speech = 'r-two';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakEnglishNamedSets Example NumSys008
  */
 sre.ClearspeakEnglishNamedSets.prototype.testNumSys008 = function() {
   var preference = 'default';
   var mathml = '<mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow>';
+  var speech = 'z-three';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys008a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys008a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mn>3</mn></msup></mrow>';
   var speech = 'z-three';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -183,11 +282,33 @@ sre.ClearspeakEnglishNamedSets.prototype.testNumSys009 = function() {
 
 
 /**
+ * Testing ClearspeakEnglishNamedSets Example NumSys009a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys009a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">C</mi><mi>n</mi></msup></mrow>';
+  var speech = 'c-n';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakEnglishNamedSets Example NumSys010
  */
 sre.ClearspeakEnglishNamedSets.prototype.testNumSys010 = function() {
   var preference = 'default';
   var mathml = '<mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow>';
+  var speech = 'r-infinity';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakEnglishNamedSets Example NumSys010a
+ */
+sre.ClearspeakEnglishNamedSets.prototype.testNumSys010a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">R</mi><mi>∞</mi></msup></mrow>';
   var speech = 'r-infinity';
   this.executeRuleTest(mathml, speech, preference);
 };

--- a/tests/en/default_char_english_test.js
+++ b/tests/en/default_char_english_test.js
@@ -3450,7 +3450,7 @@ sre.DefaultCharEnglishTest.prototype.testDefaultChars = function() {
   this.executeCharTest('∠', ['angle']);
   this.executeCharTest('∡', ['measured angle']);
   this.executeCharTest('∢', ['spherical angle']);
-  this.executeCharTest('∣', ['bar']);
+  this.executeCharTest('∣', ['vertical bar']);
   this.executeCharTest('∤', ['does not divide']);
   this.executeCharTest('∥', ['parallel to']);
   this.executeCharTest('∦', ['not parallel to']);

--- a/tests/en/mathspeak_char_english_test.js
+++ b/tests/en/mathspeak_char_english_test.js
@@ -3458,7 +3458,7 @@ sre.MathspeakCharEnglishTest.prototype.testMathspeakChars = function() {
   this.executeCharTest('∠', ['angle', 'angle', 'angle']);
   this.executeCharTest('∡', ['measured angle', 'measured angle', 'measured angle']);
   this.executeCharTest('∢', ['spherical angle', 'spherical angle', 'spherical angle']);
-  this.executeCharTest('∣', ['bar', 'bar', 'bar']);
+  this.executeCharTest('∣', ['vertical bar', 'vertical bar', 'vertical bar']);
   this.executeCharTest('∤', ['does not divide', 'does not divide', 'does not divide']);
   this.executeCharTest('∥', ['parallel to', 'parallel to', 'parallel to']);
   this.executeCharTest('∦', ['not parallel to', 'not parallel to', 'not parallel to']);

--- a/tests/fr/clearspeak_french_named_sets.js
+++ b/tests/fr/clearspeak_french_named_sets.js
@@ -84,11 +84,33 @@ sre.ClearspeakFrenchNamedSets.prototype.testNumSys002 = function() {
 
 
 /**
+ * Testing ClearspeakFrenchNamedSets Example NumSys002a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys002a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">C</mi>';
+  var speech = 'les nombres complexes';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakFrenchNamedSets Example NumSys003
  */
 sre.ClearspeakFrenchNamedSets.prototype.testNumSys003 = function() {
   var preference = 'default';
   var mathml = '<mi>ℤ</mi>';
+  var speech = 'les nombres entiers';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys003a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys003a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">Z</mi>';
   var speech = 'les nombres entiers';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -106,6 +128,17 @@ sre.ClearspeakFrenchNamedSets.prototype.testNumSys004 = function() {
 
 
 /**
+ * Testing ClearspeakFrenchNamedSets Example NumSys004a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys004a = function() {
+  var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">Q</mi>';
+  var speech = 'les Nombres rationnels';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakFrenchNamedSets Example NumSys005
  */
 sre.ClearspeakFrenchNamedSets.prototype.testNumSys005 = function() {
@@ -117,11 +150,33 @@ sre.ClearspeakFrenchNamedSets.prototype.testNumSys005 = function() {
 
 
 /**
- * Testing ClearspeakFrenchNamedSets Example NumSys005
+ * Testing ClearspeakFrenchNamedSets Example NumSys005a
  */
 sre.ClearspeakFrenchNamedSets.prototype.testNumSys005a = function() {
   var preference = 'default';
+  var mathml = '<mi mathvariant="double-struck">N</mi>';
+  var speech = 'les nombres entier naturel';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys005
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys005_1 = function() {
+  var preference = 'default';
   var mathml = '<msub><mi>ℕ</mi><mn>0</mn></msub>';
+  var speech = 'les nombres entiers naturel avec zero';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys005a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys005_1a = function() {
+  var preference = 'default';
+  var mathml = '<msub><mi mathvariant="double-struck">N</mi><mn>0</mn></msub>';
   var speech = 'les nombres entiers naturel avec zero';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -139,11 +194,33 @@ sre.ClearspeakFrenchNamedSets.prototype.testNumSys006 = function() {
 
 
 /**
- * Testing ClearspeakFrenchNamedSets Example NumSys006
+ * Testing ClearspeakFrenchNamedSets Example NumSys006a
  */
 sre.ClearspeakFrenchNamedSets.prototype.testNumSys006a = function() {
   var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mo>+</mo></msup></mrow>';
+  var speech = 'les nombres entiers positif';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys006
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys006_1 = function() {
+  var preference = 'default';
   var mathml = '<mrow><msup><mi>ℤ</mi><mo>-</mo></msup></mrow>';
+  var speech = 'les nombres entiers négatif';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys006a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys006_1a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mo>-</mo></msup></mrow>';
   var speech = 'les nombres entiers négatif';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -161,11 +238,33 @@ sre.ClearspeakFrenchNamedSets.prototype.testNumSys007 = function() {
 
 
 /**
+ * Testing ClearspeakFrenchNamedSets Example NumSys007a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys007a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">R</mi><mn>2</mn></msup></mrow>';
+  var speech = 'r-deux';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakFrenchNamedSets Example NumSys008
  */
 sre.ClearspeakFrenchNamedSets.prototype.testNumSys008 = function() {
   var preference = 'default';
   var mathml = '<mrow><msup><mi>ℤ</mi><mn>3</mn></msup></mrow>';
+  var speech = 'z-trois';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys008a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys008a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">Z</mi><mn>3</mn></msup></mrow>';
   var speech = 'z-trois';
   this.executeRuleTest(mathml, speech, preference);
 };
@@ -183,11 +282,33 @@ sre.ClearspeakFrenchNamedSets.prototype.testNumSys009 = function() {
 
 
 /**
+ * Testing ClearspeakFrenchNamedSets Example NumSys009a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys009a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">C</mi><mi>n</mi></msup></mrow>';
+  var speech = 'c-n';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
  * Testing ClearspeakFrenchNamedSets Example NumSys010
  */
 sre.ClearspeakFrenchNamedSets.prototype.testNumSys010 = function() {
   var preference = 'default';
   var mathml = '<mrow><msup><mi>ℝ</mi><mi>∞</mi></msup></mrow>';
+  var speech = 'r-infini';
+  this.executeRuleTest(mathml, speech, preference);
+};
+
+
+/**
+ * Testing ClearspeakFrenchNamedSets Example NumSys010a
+ */
+sre.ClearspeakFrenchNamedSets.prototype.testNumSys010a = function() {
+  var preference = 'default';
+  var mathml = '<mrow><msup><mi mathvariant="double-struck">R</mi><mi>∞</mi></msup></mrow>';
   var speech = 'r-infini';
   this.executeRuleTest(mathml, speech, preference);
 };


### PR DESCRIPTION
Takes care of issues #284:
* Fixes bug where `double-struck` font was checked on the wrong element.
* Deals with explicitly given `invisible plus` elements.
* Considers `divides` symbol as a potential `vertical bar`.