### PR TITLE
Issue 80

### DIFF
--- a/res/l10n/EnrichExamples.js
+++ b/res/l10n/EnrichExamples.js
@@ -478,4 +478,6 @@ Lab.Examples = ['<mrow><mrow><mi>a</mi></mrow></mrow><mrow><mi>b</mi></mrow>',
 '<mn>2</mn><mo>&#x2064;</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
 '<mn>2</mn><mo>+</mo><mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
 '<mn>2</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac><mo>+</mo><mn>2</mn>',
-'<mn>a</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>']
+'<mn>a</mn><mo>&#x2064;</mo><mfrac><mn>3</mn><mi>p</mi></mfrac>',
+'<mi><mglyph src=\'my-braid-23.png\' alt=\'23braid\'/></mi><mo>+</mo><mi><mglyph src=\'my-braid-132.png\' alt=\'132braid\'/></mi><mo>=</mo><mi><mglyph src=\'my-braid-13.png\' alt=\'13braid\'/></mi>',
+'<mrow><mi>N</mi><msub><mi>M</mi><mrow class=\'MJX-TeXAtom-ORD\'><mn>1</mn><mo>⊂</mo><mrow class=\'MJX-TeXAtom-VCENTER\'><mglyph src=\'Images/img64cf9bc6538bb7137dab7b360f92afb4.svg\' width=\'13pt\' height=\'6pt\' alt=\'mfin\'></mglyph></mrow></mrow></msub></mrow>']

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -341,8 +341,9 @@ sre.SemanticMathml.prototype.text_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.identifier_ = function(node, children) {
+  var newNode = this.leaf_(node);
   var sem = sre.SemanticProcessor.getInstance().identifierNode(
-      node.textContent,
+      newNode,
       sre.SemanticProcessor.getInstance().font(
       node.getAttribute('mathvariant')),
       node.getAttribute('class'));

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -325,10 +325,13 @@ sre.SemanticMathml.prototype.tableCell_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.text_ = function(node, children) {
+  var newNode = this.leaf_(node);
+  if (!node.textContent) {
+    return newNode;
+  }
+  newNode.updateContent(node.textContent, true);
   return sre.SemanticProcessor.getInstance().text(
-      node.textContent,
-      sre.SemanticProcessor.getInstance().font(
-          node.getAttribute('mathvariant')),
+      newNode,
       sre.DomUtil.tagName(node));
 };
 

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -516,7 +516,9 @@ sre.SemanticMathml.prototype.action_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.dummy_ = function(node, children) {
-  return this.getFactory().makeUnprocessed(node);
+  let unknown = this.getFactory().makeUnprocessed(node);
+  unknown.role = /** @type {!sre.SemanticAttr.Role} */(node.tagName);
+  return unknown;
 };
 
 

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -96,41 +96,13 @@ sre.SemanticMathml.prototype.parse = function(mml) {
   var tag = sre.DomUtil.tagName(mml);
   var func = this.parseMap_[tag];
   var newNode = (func ? func : goog.bind(this.dummy_, this))(mml, children);
-  this.addAttributes(newNode, mml);
+  sre.SemanticUtil.addAttributes(newNode, mml);
   if (['MATH', 'MROW', 'MPADDED', 'MSTYLE', 'SEMANTICS'].indexOf(tag) !== -1) {
     return newNode;
   }
   newNode.mathml.unshift(mml);
   newNode.mathmlTree = mml;
   return newNode;
-};
-
-
-/**
- * List of potential attributes that should be used as speech directly.
- * @type {Array.<string>}
- */
-sre.SemanticMathml.directSpeechKeys = ['aria-label', 'exact-speech', 'alt'];
-
-
-/**
- * Retains external attributes from the source node to the semantic node.
- * @param {sre.SemanticNode} to The target node.
- * @param {Node} from The source node.
- */
-sre.SemanticMathml.prototype.addAttributes = function(to, from) {
-  if (from.hasAttributes()) {
-    var attrs = from.attributes;
-    for (var i = attrs.length - 1; i >= 0; i--) {
-      var key = attrs[i].name;
-      if (key.match(/^ext/)) {
-        to.attributes[key] = attrs[i].value;
-      }
-      if (sre.SemanticMathml.directSpeechKeys.indexOf(key) !== -1) {
-        to.attributes['ext-speech'] = attrs[i].value;
-      }
-    }
-  }
 };
 
 
@@ -536,7 +508,7 @@ sre.SemanticMathml.prototype.dummy_ = function(node, children) {
 sre.SemanticMathml.prototype.leaf_ = function(mml, children) {
   if (children.length === 1 && children[0].nodeType !== sre.DomUtil.NodeType.TEXT_NODE) {
     let node = this.getFactory().makeUnprocessed(mml);
-    this.addAttributes(node, children[0]);
+    sre.SemanticUtil.addAttributes(node, children[0]);
     return node;
   }
   return this.getFactory().makeLeafNode(

--- a/src/semantic_tree/semantic_mathml.js
+++ b/src/semantic_tree/semantic_mathml.js
@@ -325,7 +325,7 @@ sre.SemanticMathml.prototype.tableCell_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.text_ = function(node, children) {
-  var newNode = this.leaf_(node);
+  var newNode = this.leaf_(node, children);
   if (!node.textContent) {
     return newNode;
   }
@@ -344,7 +344,7 @@ sre.SemanticMathml.prototype.text_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.identifier_ = function(node, children) {
-  var newNode = this.leaf_(node);
+  var newNode = this.leaf_(node, children);
   var sem = sre.SemanticProcessor.getInstance().identifierNode(
       newNode,
       sre.SemanticProcessor.getInstance().font(
@@ -370,7 +370,7 @@ sre.SemanticMathml.prototype.identifier_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.number_ = function(node, children) {
-  var newNode = this.leaf_(node);
+  var newNode = this.leaf_(node, children);
   sre.SemanticProcessor.number(newNode);
   return newNode;
 };
@@ -384,7 +384,7 @@ sre.SemanticMathml.prototype.number_ = function(node, children) {
  * @private
  */
 sre.SemanticMathml.prototype.operator_ = function(node, children) {
-  var newNode = this.leaf_(node);
+  var newNode = this.leaf_(node, children);
   if (newNode.type === sre.SemanticAttr.Type.UNKNOWN) {
     newNode.type = sre.SemanticAttr.Type.OPERATOR;
   }
@@ -527,16 +527,22 @@ sre.SemanticMathml.prototype.dummy_ = function(node, children) {
 
 
 /**
- * Creates a leaf node fro MathML node.
- * @param {Node} mml The MathML tree.
+ * Creates a leaf node from MathML node.
+ * @param {Node} mml The MathML node.
+ * @param {Array.<Node>} children Its child nodes.
  * @return {!sre.SemanticNode} The new node.
  * @private
  */
-sre.SemanticMathml.prototype.leaf_ = function(mml) {
+sre.SemanticMathml.prototype.leaf_ = function(mml, children) {
+  if (children.length === 1 && children[0].nodeType !== sre.DomUtil.NodeType.TEXT_NODE) {
+    let node = this.getFactory().makeUnprocessed(mml);
+    this.addAttributes(node, children[0]);
+    return node;
+  }
   return this.getFactory().makeLeafNode(
-      mml.textContent,
-      sre.SemanticProcessor.getInstance().font(
-          mml.getAttribute('mathvariant')));
+    mml.textContent,
+    sre.SemanticProcessor.getInstance().font(
+      mml.getAttribute('mathvariant')));
 };
 
 

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -65,7 +65,8 @@ sre.SemanticProcessor.prototype.getNodeFactory = function() {
 /**
  * Processes an identifier node, with particular emphasis on font disambiguation.
  * @param {sre.SemanticNode} leaf The identifier node.
- * @param {sre.SemanticAttr.Font} font The font for the identifier.
+ * @param {sre.SemanticAttr.Font} font The original mml font for the
+ *     identifier. Could be empty if not font was given.
  * @param {string} unit The class of the identifier which is important if it is
  *     a unit.
  * @return {!sre.SemanticNode} The semantic identifier node.
@@ -275,20 +276,13 @@ sre.SemanticProcessor.prototype.postfixNode_ = function(node, postfixes) {
 
 /**
  * Create an text node, keeping string notation correct.
- * @param {string} content The text content.
- * @param {sre.SemanticAttr.Font} font The font for the text.
+ * @param {sre.SemanticNode} leaf The text node.
  * @param {string} type The type of the text node.
  * @return {!sre.SemanticNode} The new semantic text node.
  */
-sre.SemanticProcessor.prototype.text = function(content, font, type) {
-  if (!content) {
-    return sre.SemanticProcessor.getInstance().factory_.makeEmptyNode();
-  }
-  var leaf = sre.SemanticProcessor.getInstance().factory_.
-      makeLeafNode(content, font);
+sre.SemanticProcessor.prototype.text = function(leaf, type) {
   // TODO (simons): Here check if there is already a type or if we can compute
   // an interesting number role. Than use this.
-  leaf.updateContent(content, true);
   leaf.type = sre.SemanticAttr.Type.TEXT;
   if (type === 'MS') {
     leaf.role = sre.SemanticAttr.Role.STRING;

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -35,7 +35,7 @@ goog.require('sre.SemanticPred');
 sre.SemanticProcessor = function() {
 
   /**
-   * @type {sre.SemanticNodeFactory}
+   * @type {!sre.SemanticNodeFactory}
    * @private
    */
   this.factory_ = new sre.SemanticNodeFactory();
@@ -54,16 +54,23 @@ sre.SemanticProcessor.prototype.setNodeFactory = function(factory) {
 
 
 /**
- * Create an identifier node, with particular emphasis on font disambiguation.
- * @param {string} content The content of the identifier.
+ * Getter for the node factory.
+ * @return {!sre.SemanticNodeFactory} The node factory.
+ */
+sre.SemanticProcessor.prototype.getNodeFactory = function() {
+  return this.factory_;
+};
+
+
+/**
+ * Processes an identifier node, with particular emphasis on font disambiguation.
+ * @param {sre.SemanticNode} leaf The identifier node.
  * @param {sre.SemanticAttr.Font} font The font for the identifier.
  * @param {string} unit The class of the identifier which is important if it is
  *     a unit.
- * @return {!sre.SemanticNode} The new semantic identifier node.
+ * @return {!sre.SemanticNode} The semantic identifier node.
  */
-sre.SemanticProcessor.prototype.identifierNode = function(content, font, unit) {
-  var leaf = sre.SemanticProcessor.getInstance().factory_.
-      makeLeafNode(content, font);
+sre.SemanticProcessor.prototype.identifierNode = function(leaf, font, unit) {
   if (unit === 'MathML-Unit') {
     leaf.type = sre.SemanticAttr.Type.IDENTIFIER;
     leaf.role = sre.SemanticAttr.Role.UNIT;

--- a/src/semantic_tree/semantic_util.js
+++ b/src/semantic_tree/semantic_util.js
@@ -229,3 +229,29 @@ sre.SemanticUtil.isZeroLength = function(length) {
 };
 
 
+/**
+ * List of potential attributes that should be used as speech directly.
+ * @type {Array.<string>}
+ */
+sre.SemanticUtil.directSpeechKeys = ['aria-label', 'exact-speech', 'alt'];
+
+
+/**
+ * Retains external attributes from the source node to the semantic node.
+ * @param {sre.SemanticNode} to The target node.
+ * @param {Node} from The source node.
+ */
+sre.SemanticUtil.addAttributes = function(to, from) {
+  if (from.hasAttributes()) {
+    var attrs = from.attributes;
+    for (var i = attrs.length - 1; i >= 0; i--) {
+      var key = attrs[i].name;
+      if (key.match(/^ext/)) {
+        to.attributes[key] = attrs[i].value;
+      }
+      if (sre.SemanticUtil.directSpeechKeys.indexOf(key) !== -1) {
+        to.attributes['ext-speech'] = attrs[i].value;
+      }
+    }
+  }
+};

--- a/src/speech_rules/mathspeak_util.js
+++ b/src/speech_rules/mathspeak_util.js
@@ -58,7 +58,8 @@ sre.MathspeakUtil.spaceoutNodes = function(node, correction) {
   var processor = sre.SemanticProcessor.getInstance();
   var doc = node.ownerDocument;
   for (var i = 0, chr; chr = content[i]; i++) {
-    var sn = processor.identifierNode(chr, sre.Semantic.Font.UNKNOWN, '');
+    var leaf = processor.getNodeFactory().makeLeafNode(chr, sre.Semantic.Font.UNKNOWN);
+    var sn = processor.identifierNode(leaf, sre.Semantic.Font.UNKNOWN, '');
     correction(sn);
     result.push(sn.xml(doc));
   }

--- a/src/walker/rebuild_stree.js
+++ b/src/walker/rebuild_stree.js
@@ -88,6 +88,22 @@ sre.RebuildStree.prototype.getTree = function() {
 
 
 /**
+ * Adds external attributes if they exists. Recurses one level if we have a leaf
+ * element with a none-text child.
+ * @param {sre.SemanticNode} snode The semantic node.
+ * @param {Node} node The mml node.
+ * @param {boolean} leaf True if it is a leaf node.
+ */
+sre.RebuildStree.addAttributes = function(snode, node, leaf) {
+  if (leaf && node.childNodes.length === 1 &&
+      node.childNodes[0].nodeType !== sre.DomUtil.NodeType.TEXT_NODE) {
+    sre.SemanticUtil.addAttributes(snode, node.childNodes[0]);
+  }
+  sre.SemanticUtil.addAttributes(snode, node);
+};
+
+
+/**
  * Assembles the semantic tree from the data attributes of the MathML node.
  * @param {!Node} node The MathML node.
  * @return {!sre.SemanticNode} The corresponding semantic tree node.
@@ -98,6 +114,7 @@ sre.RebuildStree.prototype.assembleTree = function(node) {
       sre.WalkerUtil.getAttribute(node, sre.EnrichMathml.Attribute.CHILDREN));
   var content = sre.WalkerUtil.splitAttribute(
       sre.WalkerUtil.getAttribute(node, sre.EnrichMathml.Attribute.CONTENT));
+  sre.RebuildStree.addAttributes(snode, node, !(children.length || content.length));
   if (content.length === 0 && children.length === 0) {
     snode.textContent = node.textContent;
     return snode;

--- a/tests/base/base_tests.js
+++ b/tests/base/base_tests.js
@@ -18,6 +18,7 @@ goog.provide('sre.BaseTests');
 goog.require('sre.ApiTest');
 goog.require('sre.ClearspeakAnnotationTest');
 goog.require('sre.ColorPickerTest');
+goog.require('sre.DirectSpeechTest');
 goog.require('sre.DomTest');
 goog.require('sre.EnrichMathmlTest');
 goog.require('sre.EnrichSpeechTest');
@@ -40,6 +41,7 @@ sre.BaseTests.testList = [
   sre.ApiTest,
   sre.ClearspeakAnnotationTest,
   sre.ColorPickerTest,
+  sre.DirectSpeechTest,
   sre.DomTest,
   sre.EnrichMathmlTest,
   sre.EnrichSpeechTest,

--- a/tests/base/direct_speech_test.js
+++ b/tests/base/direct_speech_test.js
@@ -1,0 +1,192 @@
+// Copyright 2020 Volker Sorge
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Testcases for direct speech integration.
+ * @author Volker.Sorge@mathjax.org (Volker Sorge)
+ */
+
+goog.provide('sre.DirectSpeechTest');
+
+goog.require('sre.AbstractRuleTest');
+goog.require('sre.EnrichMathmlTest');
+goog.require('sre.RebuildStreeTest');
+goog.require('sre.SemanticTreeTest');
+
+
+/**
+ * @constructor
+ * @extends {sre.AbstractRuleTest}
+ */
+sre.DirectSpeechTest = function() {
+  sre.DirectSpeechTest.base(this, 'constructor');
+
+  /**
+   * @override
+   */
+  this.information = 'Tests for Direct speech attributes.';
+
+  this.setActive('DirectSpeech');
+};
+goog.inherits(sre.DirectSpeechTest, sre.AbstractRuleTest);
+
+
+/**
+ * Testing Aria Labels.
+ */
+sre.DirectSpeechTest.prototype.testAriaLabels = function() {
+  var mml = '<mover> <mi>AC</mi> <mo stretchy="true" aria-label="line">↔</mo> </mover>';
+  this.domain = 'mathspeak';
+  this.executeRuleTest(mml, 'ModifyingAbove upper A upper C With line');
+  this.domain = 'clearspeak';
+  this.executeRuleTest(mml, 'AC line');
+  mml = '<mover aria-label="derivative of x"><mi>x</mi><mo>&#x02D9;<!-- ˙ --></mo>' +
+    '</mover><mi></mi><mo aria-label="is equal to">=</mo>' +
+    '<mi aria-label="sigma">&#x03C3;<!-- σ --></mi><mrow>' +
+    '<mo aria-label="left parenthesis" stretchy="false">(</mo>' +
+    '<mi aria-label="y">y</mi><mo aria-label="minus">&#x2212;<!-- − --></mo>' +
+    '<mi aria-label="x">x</mi>' +
+    '<mo aria-label="right parenthesis" stretchy="false">)</mo></mrow>';
+  this.domain = 'mathspeak';
+  this.executeRuleTest(mml, 'derivative of x is equal to sigma left parenthesis y minus x right parenthesis');
+  this.domain = 'clearspeak';
+  this.executeRuleTest(mml, 'derivative of x is equal to sigma times left parenthesis y minus x right parenthesis');
+};
+
+
+/**
+ * Testing Alt Text.
+ */
+sre.DirectSpeechTest.prototype.testAltText = function() {
+  var mml = '<math alt="A C under line"><mover> <mi>AC</mi>'
+      + ' <mo stretchy="true">↔</mo> </mover></math>';
+  this.domain = 'mathspeak';
+  this.executeRuleTest(mml, 'A C under line');
+  this.domain = 'clearspeak';
+  this.executeRuleTest(mml, 'A C under line');
+  mml = '<mover> <mi>AC</mi>'
+      + ' <mo stretchy="true" alt="line">↔</mo> </mover>';
+  this.domain = 'mathspeak';
+  this.executeRuleTest(mml, 'ModifyingAbove upper A upper C With line');
+  this.domain = 'clearspeak';
+  this.executeRuleTest(mml, 'AC line');
+};
+
+
+/**
+ * Testing Exact Speech.
+ */
+sre.DirectSpeechTest.prototype.testExactSpeech = function() {
+  var mml = '<math exact-speech="A C under line"><mover> <mi>AC</mi>'
+      + ' <mo stretchy="true">↔</mo> </mover></math>';
+  this.domain = 'mathspeak';
+  this.executeRuleTest(mml, 'A C under line');
+  this.domain = 'clearspeak';
+  this.executeRuleTest(mml, 'A C under line');
+  mml = '<mover> <mi>AC</mi>'
+      + ' <mo stretchy="true" exact-speech="line">↔</mo> </mover>';
+  this.domain = 'mathspeak';
+  this.executeRuleTest(mml, 'ModifyingAbove upper A upper C With line');
+  this.domain = 'clearspeak';
+  this.executeRuleTest(mml, 'AC line');
+};
+
+
+/**
+ * Testing mglpyhs in tokens.
+ */
+sre.DirectSpeechTest.prototype.testMglyphTokens = function() {
+  this.domain = 'mathspeak';
+  // mi
+  var mml = '<mi><mglyph src="my-glyph.png" alt="my glyph"/></mi>';
+  this.executeRuleTest(mml, 'my glyph');
+  mml = '<mi aria-label="your glyph"><mglyph src="my-glyph.png" alt="my glyph"/></mi>';
+  this.executeRuleTest(mml, 'your glyph');
+  // mo
+  mml = '<mo><mglyph src="my-glyph.png" alt="my glyph"/></mo>';
+  this.executeRuleTest(mml, 'my glyph');
+  mml = '<mo aria-label="your glyph"><mglyph src="my-glyph.png" alt="my glyph"/></mo>';
+  this.executeRuleTest(mml, 'your glyph');
+  // mn
+  mml = '<mn><mglyph src="my-glyph.png" alt="my glyph"/></mn>';
+  this.executeRuleTest(mml, 'my glyph');
+  mml = '<mn aria-label="your glyph"><mglyph src="my-glyph.png" alt="my glyph"/></mn>';
+  this.executeRuleTest(mml, 'your glyph');
+  // mtext
+  mml = '<mtext><mglyph src="my-glyph.png" alt="my glyph"/></mtext>';
+  this.executeRuleTest(mml, 'my glyph');
+  mml = '<mtext aria-label="your glyph"><mglyph src="my-glyph.png" alt="my glyph"/></mtext>';
+  this.executeRuleTest(mml, 'your glyph');
+  // ms
+  mml = '<ms><mglyph src="my-glyph.png" alt="my glyph"/></ms>';
+  this.executeRuleTest(mml, 'my glyph');
+  mml = '<ms aria-label="your glyph"><mglyph src="my-glyph.png" alt="my glyph"/></ms>';
+  this.executeRuleTest(mml, 'your glyph');
+};
+
+
+/**
+ * Testing mglpyhs.
+ */
+sre.DirectSpeechTest.prototype.testMglyphGeneral = function() {
+  this.domain = 'mathspeak';
+  var mml = '<mi><mglyph src="my-braid-23.png" alt="23braid"/></mi>' +
+    '<mo>+</mo><mi><mglyph src="my-braid-132.png" alt="132braid"/></mi>' +
+      '<mo>=</mo><mi><mglyph src="my-braid-13.png" alt="13braid"/></mi>';
+  this.executeRuleTest(mml, '23braid plus 132braid equals 13braid');
+  mml = '<mrow><mi>N</mi><msub><mi>M</mi><mrow class="MJX-TeXAtom-ORD">' +
+    '<mn>1</mn><mo>⊂</mo><mrow class="MJX-TeXAtom-VCENTER">' +
+    '<mglyph src="Images/img64cf9bc6538bb7137dab7b360f92afb4.svg" width="13pt"' +
+    ' height="6pt" alt="mfin"></mglyph></mrow></mrow></msub></mrow>';
+  this.executeRuleTest(mml, 'upper N upper M Subscript 1 subset of mfin');
+};
+
+
+sre.SemanticTreeTest.prototype.testMglyph = function() {
+  var mml = '<mi><mglyph src="my-braid-23.png" alt="23braid"/></mi>' +
+    '<mo>+</mo><mi><mglyph src="my-braid-132.png" alt="132braid"/></mi>' +
+      '<mo>=</mo><mi><mglyph src="my-braid-13.png" alt="13braid"/></mi>';
+  this.executeTreeTest(mml, '<relseq role="equality" id="6">=<content><relation role="equality" id="3">=</relation></content><children><infixop role="addition" id="5">+<content><operator role="addition" id="1">+</operator></content><children><identifier role="unknown" id="0" ext-speech="23braid"/><identifier role="unknown" id="2" ext-speech="132braid"/></children></infixop><identifier role="unknown" id="4" ext-speech="13braid"/></children></relseq>');
+  mml = '<mrow><mi>N</mi><msub><mi>M</mi><mrow class="MJX-TeXAtom-ORD">' +
+    '<mn>1</mn><mo>⊂</mo><mrow class="MJX-TeXAtom-VCENTER">' +
+    '<mglyph src="Images/img64cf9bc6538bb7137dab7b360f92afb4.svg" width="13pt"' +
+    ' height="6pt" alt="mfin"></mglyph></mrow></mrow></msub></mrow>';
+  this.executeTreeTest(mml, '<infixop role="implicit" id="8">⁢<content><operator role="multiplication" id="7">⁢</operator></content><children><identifier role="latinletter" font="italic" id="0">N</identifier><subscript role="latinletter" id="6"><children><identifier role="latinletter" font="italic" id="1">M</identifier><infixop role="unknown" id="5">⊂<content><operator role="unknown" id="3">⊂</operator></content><children><number role="integer" font="normal" id="2">1</number><unknown role="mglyph" id="4" ext-speech="mfin"/></children></infixop></subscript></infixop>');
+};
+
+
+sre.EnrichMathmlTest.prototype.testMglyph = function() {
+  var mml = '<mi><mglyph src="my-braid-23.png" alt="23braid"/></mi>' +
+    '<mo>+</mo><mi><mglyph src="my-braid-132.png" alt="132braid"/></mi>' +
+      '<mo>=</mo><mi><mglyph src="my-braid-13.png" alt="13braid"/></mi>';
+  this.executeMathmlTest(mml, '<math type="relseq" role="equality" id="6" children="5,4" content="3"><mrow type="infixop" role="addition" id="5" children="0,2" content="1" parent="6"><mi type="identifier" role="unknown" id="0" parent="5"><mglyph src="my-braid-23.png" alt="23braid"/></mi><mo type="operator" role="addition" id="1" parent="5" operator="infixop,+">+</mo><mi type="identifier" role="unknown" id="2" parent="5"><mglyph src="my-braid-132.png" alt="132braid"/></mi></mrow><mo type="relation" role="equality" id="3" parent="6" operator="relseq,=">=</mo><mi type="identifier" role="unknown" id="4" parent="6"><mglyph src="my-braid-13.png" alt="13braid"/></mi></math>');
+  mml = '<mrow><mi>N</mi><msub><mi>M</mi><mrow class="MJX-TeXAtom-ORD">' +
+    '<mn>1</mn><mo>⊂</mo><mrow class="MJX-TeXAtom-VCENTER">' +
+    '<mglyph src="Images/img64cf9bc6538bb7137dab7b360f92afb4.svg" width="13pt"' +
+    ' height="6pt" alt="mfin"></mglyph></mrow></mrow></msub></mrow>';
+  this.executeMathmlTest(mml, '<math><mrow type="infixop" role="implicit" id="8" children="0,6" content="7"><mi type="identifier" role="latinletter" id="0" parent="8">N</mi><mo type="operator" role="multiplication" id="7" parent="8" added="true" operator="infixop,⁢">⁢</mo><msub type="subscript" role="latinletter" id="6" children="1,5" parent="8"><mi type="identifier" role="latinletter" id="1" parent="6">M</mi><mrow class="MJX-TeXAtom-ORD" type="infixop" role="unknown" id="5" children="2,4" content="3" parent="6"><mn type="number" role="integer" id="2" parent="5">1</mn><mo type="operator" role="unknown" id="3" parent="5" operator="infixop,⊂">⊂</mo><mrow class="MJX-TeXAtom-VCENTER"><mglyph src="Images/img64cf9bc6538bb7137dab7b360f92afb4.svg" width="13pt" height="6pt" alt="mfin" type="unknown" role="mglyph" id="4" parent="5"/></mrow></mrow></msub></mrow></math>');
+};
+
+
+sre.RebuildStreeTest.prototype.untestMglyph = function() {
+  var mml = '<mi><mglyph src="my-braid-23.png" alt="23braid"/></mi>' +
+    '<mo>+</mo><mi><mglyph src="my-braid-132.png" alt="132braid"/></mi>' +
+      '<mo>=</mo><mi><mglyph src="my-braid-13.png" alt="13braid"/></mi>';
+  this.executeRebuildTest(mml);
+  mml = '<mrow><mi>N</mi><msub><mi>M</mi><mrow class="MJX-TeXAtom-ORD">' +
+    '<mn>1</mn><mo>⊂</mo><mrow class="MJX-TeXAtom-VCENTER">' +
+    '<mglyph src="Images/img64cf9bc6538bb7137dab7b360f92afb4.svg" width="13pt"' +
+    ' height="6pt" alt="mfin"></mglyph></mrow></mrow></msub></mrow>';
+  this.executeRebuildTest(mml);
+};

--- a/tests/base/direct_speech_test.js
+++ b/tests/base/direct_speech_test.js
@@ -179,7 +179,7 @@ sre.EnrichMathmlTest.prototype.testMglyph = function() {
 };
 
 
-sre.RebuildStreeTest.prototype.untestMglyph = function() {
+sre.RebuildStreeTest.prototype.testMglyph = function() {
   var mml = '<mi><mglyph src="my-braid-23.png" alt="23braid"/></mi>' +
     '<mo>+</mo><mi><mglyph src="my-braid-132.png" alt="132braid"/></mi>' +
       '<mo>=</mo><mi><mglyph src="my-braid-13.png" alt="13braid"/></mi>';


### PR DESCRIPTION
This PR provide support for `mglyph`-like elements. That is, all unknown elements that contain a direct speech attribute (e.g, `alt`, `aria-label`) are considered. 
* Elements found in (inferred) rows are handled as `unknown` elements with speech.
* Those embedded as singletons in token elements (`mi`, `mo`, etc.) are treated in their context. E.g., 
```html
<mo><mglyph alt="x"/></mo>
```
is treated as an operator and spoken as `x`. Direct speech attributes on the token will supersede the ones in the lower layer.
* **There is no support for mixed elements yet.** Currently it will simply ignore any `mglyph`. I'll treat  that when I see a real world example. 

This handles all examples from issue #80 and the ones I found built by Bruce Miller.