### PR TITLE
Maps default domain to mathspeak.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ maps: $(JSON_DST) clean_loc $(LOC_DST)
 
 clean_loc:
 	@if ! [ -z $(LOC) ]; then \
-		echo "Deleteing $(LOC).js"; \
+		echo "Deleting $(LOC).js"; \
 		rm -f $(JSON_DST)/$(LOC).js; \
 	fi
 
@@ -282,11 +282,13 @@ $(LOC_DST):
 	@echo "Creating mappings for locale `basename $@ .js`."
 	@echo '{' > $@
 	@for dir in $(MAPS); do\
-		for i in $(JSON_SRC)/`basename $@ .js`/$$dir/*.js; do\
-			echo '"'`basename $@ .js`/$$dir/`basename $$i`'": '  >> $@; \
-			$(JSON_MINIFY) $$i >> $@; \
-			echo ','  >> $@; \
-		done; \
+		if [ -d $(JSON_SRC)/`basename $@ .js`/$$dir ]; then \
+			for i in $(JSON_SRC)/`basename $@ .js`/$$dir/*.js; do\
+				echo '"'`basename $@ .js`/$$dir/`basename $$i`'": '  >> $@; \
+				$(JSON_MINIFY) $$i >> $@; \
+				echo ','  >> $@; \
+			done; \
+		fi; \
 	done
 	@sed '$$d' $@ > $@.tmp
 	@echo '}' >> $@.tmp
@@ -300,11 +302,13 @@ $(IEMAPS_FILE):
 	@echo 'sre.BrowserUtil.mapsForIE = {' > $(IEMAPS_FILE)
 	@for j in $(LOCALES); do\
 		for dir in $(MAPS); do\
-			for i in $(JSON_SRC)/$$j/$$dir/*.js; do\
-				echo '"'`basename $$j`/$$dir/`basename $$i`'": '  >> $(IEMAPS_FILE); \
-				$(JSON_MINIFY) $$i >> $(IEMAPS_FILE); \
-				echo ','  >> $(IEMAPS_FILE); \
-			done; \
+			if [ -d $(JSON_SRC)/`basename $@ .js`/$$dir ]; then \
+				for i in $(JSON_SRC)/$$j/$$dir/*.js; do\
+					echo '"'`basename $$j`/$$dir/`basename $$i`'": '  >> $(IEMAPS_FILE); \
+					$(JSON_MINIFY) $$i >> $(IEMAPS_FILE); \
+					echo ','  >> $(IEMAPS_FILE); \
+				done; \
+			fi; \
 		done; \
 	done
 	@sed '$$d' $(IEMAPS_FILE) > $(IEMAPS_FILE).tmp

--- a/src/common/system.js
+++ b/src/common/system.js
@@ -60,6 +60,16 @@ goog.addSingletonGetter(sre.System);
  */
 sre.System.prototype.setupEngine = function(feature) {
   var engine = sre.Engine.getInstance();
+  // This preserves the possibility to specify default as domain.
+  //
+  // < 3.2  this lead to the use of chromevox rules in English.
+  // >= 3.2 this defaults to Mathspeak. It also ensures that in other locales we
+  //        get a meaningful output.
+  if (feature.domain === 'default' &&
+      (feature.modality === 'speech' ||
+       (!feature.modality || engine.modality === 'speech'))) {
+    feature.domain = 'mathspeak';
+  }
   var setIf = function(feat) {
     if (typeof feature[feat] !== 'undefined') {
       engine[feat] = !!feature[feat];

--- a/src/mathmaps/en/rules/chromevox.js
+++ b/src/mathmaps/en/rules/chromevox.js
@@ -1,6 +1,6 @@
 {
   "locale": "en",
-  "domain": "default",
+  "domain": "chromevox",
   "modality": "speech",
   "rules": [
     [

--- a/src/rule_engine/speech_rule_engine.js
+++ b/src/rule_engine/speech_rule_engine.js
@@ -612,10 +612,12 @@ sre.SpeechRuleEngine.prototype.updateConstraint_ = function() {
     }
   }
   props[sre.DynamicCstr.Axis.LOCALE] = [locale];
+  // Normally modality cannot be mixed. But summary allows fallback to speech if
+  // an expression can not be summarised.
   props[sre.DynamicCstr.Axis.MODALITY] =
-      // TODO: Improve, only summary allows fallback to speech.
       [modality !== 'summary' ? modality :
        sre.DynamicCstr.DEFAULT_VALUES[sre.DynamicCstr.Axis.MODALITY]];
+  // For speech we do not want rule leaking across rule sets.
   props[sre.DynamicCstr.Axis.DOMAIN] =
       [modality !== 'speech' ?
        sre.DynamicCstr.DEFAULT_VALUES[sre.DynamicCstr.Axis.DOMAIN] : domain];

--- a/src/speech_rules/other_rules.js
+++ b/src/speech_rules/other_rules.js
@@ -40,14 +40,14 @@ sre.PrefixRules = function() {
 
 sre.OtherRules = function() {
   sre.SpeechRules.getInstance().addStore(
-    'en.speech.default', '', 
+    'en.speech.chromevox', '',
     {
       'CTFnodeCounter': sre.StoreUtil.nodeCounter,
       'CTFcontentIterator': sre.StoreUtil.contentIterator
     });
 
   sre.SpeechRules.getInstance().addStore(
-    'en.speech.emacspeak', 'en.speech.default', 
+    'en.speech.emacspeak', 'en.speech.chromevox',
     {
       'CQFvulgarFractionSmall': sre.MathspeakUtil.isSmallVulgarFraction,
       'CSFvulgarFraction': sre.NumbersUtil.vulgarFraction
@@ -74,5 +74,5 @@ sre.BrailleRules = function() {
 
       'CGFtensorRules': sre.NemethUtil.generateTensorRules
     });
-  
+
 };


### PR DESCRIPTION
* Maps default domain to be MathSpeak
* Renames the `default` set to `chromevox`

Fixes two major problems:
* In locale `en`: Forgetting to specify a rule set leads to the original ChromeVox rules being used, which are very ambiguous without full prosody.
* If selecting a locale other than `en` without explicitly specifying a rule set, the output would be garbage.