### PR TITLE
Issue 451

### DIFF
--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -1618,9 +1618,6 @@ sre.SemanticProcessor.classifyFunction_ = function(funcNode, restNodes) {
   // Find and remove explicit function applications.
   // We now treat funcNode as a prefix function, regardless of what its actual
   // content is.
-  //
-  // TODO: ISSUE #451: If the funcNode here is not a single element but, e.g.,
-  //       an infix operator, then we must not simply propagate!
   if (restNodes[0] &&
       restNodes[0].textContent === sre.SemanticAttr.functionApplication()) {
     // Remove explicit function application. This is destructive on the
@@ -1632,7 +1629,11 @@ sre.SemanticProcessor.classifyFunction_ = function(funcNode, restNodes) {
         funcNode.role === sre.SemanticAttr.Role.LIMFUNC) {
       role = funcNode.role;
     }
-    sre.SemanticProcessor.propagateFunctionRole_(funcNode, role);
+    if (!funcNode.type === sre.Semantic.Type.INFIXOP) {
+      sre.SemanticProcessor.propagateFunctionRole_(funcNode, role);
+    } else {
+      funcNode.role = role;
+    }
     return 'prefix';
   }
   var kind = sre.SemanticProcessor.CLASSIFY_FUNCTION_[funcNode.role];

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -1629,7 +1629,7 @@ sre.SemanticProcessor.classifyFunction_ = function(funcNode, restNodes) {
         funcNode.role === sre.SemanticAttr.Role.LIMFUNC) {
       role = funcNode.role;
     }
-    if (!funcNode.type === sre.Semantic.Type.INFIXOP) {
+    if (funcNode.type !== sre.Semantic.Type.INFIXOP) {
       sre.SemanticProcessor.propagateFunctionRole_(funcNode, role);
     } else {
       funcNode.role = role;

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -1593,7 +1593,6 @@ sre.SemanticProcessor.CLASSIFY_FUNCTION_[sre.SemanticAttr.Role.PREFIXFUNC] =
     'prefix';
 sre.SemanticProcessor.CLASSIFY_FUNCTION_[sre.SemanticAttr.Role.LIMFUNC] =
     'prefix';
-// TODO (WS2.3): Should go into clearspeak specific parser/processor?
 sre.SemanticProcessor.CLASSIFY_FUNCTION_[sre.SemanticAttr.Role.SIMPLEFUNC] =
     'prefix';
 sre.SemanticProcessor.CLASSIFY_FUNCTION_[sre.SemanticAttr.Role.COMPFUNC] =
@@ -1619,6 +1618,9 @@ sre.SemanticProcessor.classifyFunction_ = function(funcNode, restNodes) {
   // Find and remove explicit function applications.
   // We now treat funcNode as a prefix function, regardless of what its actual
   // content is.
+  //
+  // TODO: ISSUE #451: If the funcNode here is not a single element but, e.g.,
+  //       an infix operator, then we must not simply propagate!
   if (restNodes[0] &&
       restNodes[0].textContent === sre.SemanticAttr.functionApplication()) {
     // Remove explicit function application. This is destructive on the
@@ -1649,7 +1651,8 @@ sre.SemanticProcessor.classifyFunction_ = function(funcNode, restNodes) {
  */
 sre.SemanticProcessor.propagateFunctionRole_ = function(funcNode, tag) {
   if (funcNode) {
-    if (!sre.SemanticPred.isAttribute('role', 'SUBSUP')(funcNode)) {
+    if (!(sre.SemanticPred.isAttribute('role', 'SUBSUP')(funcNode) ||
+          sre.SemanticPred.isAttribute('role', 'UNDEROVER')(funcNode))) {
       funcNode.role = tag;
     }
     sre.SemanticProcessor.propagateFunctionRole_(funcNode.childNodes[0], tag);
@@ -1821,7 +1824,7 @@ sre.SemanticProcessor.prototype.functionNode_ = function(func, arg) {
             (sre.SemanticPred.isAttribute('type', 'IDENTIFIER')(node) &&
              sre.SemanticPred.isAttribute('role', 'SIMPLEFUNC')(node));
       }
-      );
+  );
   return sre.SemanticProcessor.getInstance().functionalNode_(
       sre.SemanticAttr.Type.APPL, [func, arg], funcop, [applNode]);
 };


### PR DESCRIPTION
Fixes issue #451  by stopping role propagation into composed function heads. Two notes:

* This could interfere with the new operator heuristic `texclassOP` in `operator_heuristic` branch.
* Could subsumed or be merged with the clearspeak `propagateSimpleFunction` heuristic.