### PR TITLE
Enrich juxta heuristic

### DIFF
--- a/src/enrich_mathml/enrich_mathml.js
+++ b/src/enrich_mathml/enrich_mathml.js
@@ -178,7 +178,7 @@ sre.EnrichMathml.walkTree = function(semantic) {
     }
   }
   newNode = sre.EnrichMathml.rewriteMfenced(newNode);
-  sre.EnrichMathml.mergeChildren_(newNode, childrenList);
+  sre.EnrichMathml.mergeChildren_(newNode, childrenList, semantic);
   sre.EnrichMathml.setAttributes(newNode, semantic);
   let res = sre.EnrichMathml.ascendNewNode(newNode);
   return res;
@@ -302,18 +302,38 @@ sre.EnrichMathml.childrenSubset_ = function(node, newChildren) {
 };
 
 
+// sre.EnrichMathml.collateChildNodes_ = function(node, newChildren) {
+//   var oldChildren = [];
+//   for ()
+//   if ()
+// }
+
 /**
  * Merges a list of new children with the children of the given node.
  * @param {!Element} node The node whose children are merged.
  * @param {!Array.<Element>} newChildren The list of children to be merged.
+ * @param {!sre.SemanticNode} semantic The semantic node whose children are
+ *     merged.
  * @private
  */
-sre.EnrichMathml.mergeChildren_ = function(node, newChildren) {
+sre.EnrichMathml.mergeChildren_ = function(node, newChildren, semantic) {
+  // console.log('Merging');
+  // console.log('Newchildren');
+  // newChildren.forEach(x => {console.log(x); console.log(x.getAttribute('data-semantic-type'));});
+
+  // var oldChildren = (semantic.role === sre.SemanticAttr.Role.IMPLICIT) ?
+  //     sre.EnrichMathml.collateChildNodes_(node, newChildren) :
+  //     /**@type{!NodeList.<Element>}*/ (node.childNodes);
   var oldChildren = /**@type{!NodeList.<Element>}*/ (node.childNodes);
+
+
   if (!oldChildren.length) {
     newChildren.forEach(function(x) {node.appendChild(x);});
     return;
   }
+  // console.log('Oldchildren');
+  // oldChildren = [oldChildren[0], oldChildren[1], oldChildren[2].childNodes[0], oldChildren[2].childNodes[1], oldChildren[2].childNodes[2]];
+  // oldChildren.forEach(x => {console.log(x); console.log(x.getAttribute('data-semantic-type'));});
   var oldCounter = 0;
   while (newChildren.length) {
     // TODO (sorge) This special case is only necessary, because explicit
@@ -338,7 +358,12 @@ sre.EnrichMathml.mergeChildren_ = function(node, newChildren) {
       newChildren.shift();
       continue;
     }
-    node.insertBefore(newChildren[0], oldChildren[oldCounter] || null);
+    if (oldChildren[oldCounter]) {
+      oldChildren[oldCounter].parentNode.insertBefore(newChildren[0], oldChildren[oldCounter]);
+    } else {
+      node.insertBefore(newChildren[0], null);
+    }
+    // node.insertBefore(newChildren[0], oldChildren[oldCounter] || null);
     newChildren.shift();
   }
 };

--- a/src/enrich_mathml/enrich_mathml.js
+++ b/src/enrich_mathml/enrich_mathml.js
@@ -346,8 +346,11 @@ sre.EnrichMathml.collateChildNodes_ = function(node) {
 sre.EnrichMathml.collectChildNodes_ = function(node) {
   var collect = [];
   var newChildren = sre.DomUtil.toArray(node.childNodes);
+  console.log('Collecting Children for');
+  console.log(node);
   while (newChildren.length) {
     var child = newChildren.shift();
+    console.log(child);
     if (child.nodeType !== sre.DomUtil.NodeType.ELEMENT_NODE) {
       continue;
     }
@@ -357,6 +360,7 @@ sre.EnrichMathml.collectChildNodes_ = function(node) {
     }
     newChildren = sre.DomUtil.toArray(child.childNodes).concat(newChildren);
   }
+  console.log('Done Collecting Children');
   return collect;
 };
 
@@ -378,9 +382,9 @@ sre.EnrichMathml.collectChildNodes_ = function(node) {
  * @private
  */
 sre.EnrichMathml.mergeChildren_ = function(node, newChildren, semantic) {
-  // console.log('Merging');
-  // console.log('Newchildren');
-  // newChildren.forEach(x => {console.log(x); console.log(x.getAttribute('data-semantic-type'));});
+  console.log('Merging');
+  console.log('Newchildren');
+  newChildren.forEach(x => console.log(x));
 
   console.log(5);
   console.log(semantic.type);
@@ -395,10 +399,15 @@ sre.EnrichMathml.mergeChildren_ = function(node, newChildren, semantic) {
     newChildren.forEach(function(x) {node.appendChild(x);});
     return;
   }
+  console.log('Original children');
+  sre.DomUtil.toArray(node.childNodes).forEach(x => console.log(x));
   console.log('Oldchildren');
-  // oldChildren.forEach(x => {console.log(x.toString()); console.log(x.getAttribute('data-semantic-type'));});
+  oldChildren.forEach(x => console.log(x));
   var oldCounter = 0;
   while (newChildren.length) {
+    console.log('Comparison: ' + (oldChildren[oldCounter] === newChildren[0]));
+    console.log(oldChildren[oldCounter]);
+    console.log(newChildren[0]);
     // TODO (sorge) This special case is only necessary, because explicit
     // function applications are destructively dropped in the semantic tree
     // computation. This should be addressed in the future!
@@ -744,6 +753,8 @@ sre.EnrichMathml.cloneContentNode = function(content) {
   if (content.mathml.length) {
     return sre.EnrichMathml.walkTree(content);
   }
+  console.log('Cloning');
+  console.log(content);
   var clone = sre.EnrichMathml.SETTINGS.implicit ?
       sre.EnrichMathml.createInvisibleOperator_(content) :
       sre.DomUtil.createElement('mrow');
@@ -820,6 +831,7 @@ sre.EnrichMathml.rewriteMfenced = function(mml) {
  * @private
  */
 sre.EnrichMathml.createInvisibleOperator_ = function(operator) {
+  console.log(7);
   var moNode = sre.DomUtil.createElement('mo');
   var text = sre.DomUtil.createTextNode(operator.textContent);
   moNode.appendChild(text);

--- a/src/semantic_tree/semantic_heuristics.js
+++ b/src/semantic_tree/semantic_heuristics.js
@@ -481,9 +481,9 @@ sre.SemanticHeuristics.recurseJuxtaposition_ = function(acc, ops, elements) {
     // right = sre.SemanticPred.isOperator(op) ? [left] : [left, op];
     // op.mathmlTree.setAttribute('AuxiliaryRemoved', true);
     // right = [left, op]; // .concat(first);
-    if (!ops.length) {
-      return sre.SemanticHeuristics.recurseJuxtaposition_(acc.concat(left), ops, elements);
-    }
+    // if (!ops.length) {
+    //   return sre.SemanticHeuristics.recurseJuxtaposition_(acc.concat(left), ops, elements);
+    // }
     var newOp = sre.SemanticHeuristics.getInstance().factory.makeBranchNode(
       sre.SemanticAttr.Type.INFIXOP, [left, ops.shift()], [op], op.textContent);
     newOp.role = sre.SemanticAttr.Role.IMPLICIT;

--- a/src/semantic_tree/semantic_heuristics.js
+++ b/src/semantic_tree/semantic_heuristics.js
@@ -412,11 +412,11 @@ sre.SemanticHeuristics.convertPrePost_ = function(collect, next, comps, rels) {
   if (prevExists && nextExists) {
     if (next[0].type === sre.SemanticAttr.Type.INFIXOP &&
         next[0].role === sre.SemanticAttr.Role.IMPLICIT) {
-      rels.push(collect.pop());
+      rels.unshift(collect.pop());
       prev.push(sre.SemanticProcessor.getInstance()['postfixNode_'](prev.pop(), collect));
       return;
     }
-    rels.push(collect.shift());
+    rels.unshift(collect.shift());
     next.unshift(sre.SemanticProcessor.getInstance()['prefixNode_'](next.shift(), collect));
     return;
   }

--- a/src/semantic_tree/semantic_heuristics.js
+++ b/src/semantic_tree/semantic_heuristics.js
@@ -398,7 +398,7 @@ sre.SemanticHeuristics.juxtapositionPrePost_ = function(partition) {
 /**
  * Converts lists of invisible times operators into pre/postfix operatiors.
  * @param {!Array.<sre.SemanticNode>} collect The collected list of invisible
- *     etimes.
+ *     times.
  * @param {!Array.<sre.SemanticNode>} next The next component element.
  * @param {!Array.<!Array.<sre.SemanticNode>>} comps The previous components.
  * @return {sre.SemanticNode|null} The operator that needs to be taken care of.
@@ -460,41 +460,31 @@ sre.SemanticHeuristics.recurseJuxtaposition_ = function(acc, ops, elements) {
   var op = ops.shift();
   var first = elements.shift();
   if (sre.SemanticPred.isImplicitOp(op)) {
-    sre.Debugger.getInstance().output('Case 2');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 2');
     // In case we have a tree as operator, move on.
-    // TODO: Simplify with Case 9?
     var right = (left ? [left, op] : [op]).concat(first);
     return sre.SemanticHeuristics.recurseJuxtaposition_(
       acc.concat(right), ops, elements);
   }
   if (!left) {
-    sre.Debugger.getInstance().output('Case 3');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 3');
     return sre.SemanticHeuristics.recurseJuxtaposition_([op].concat(first), ops, elements);
   }
   var right = first.shift();
   if (!right) {
-    sre.Debugger.getInstance().output('Case 9');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 9');
     // Attach to the next operator, which must be an infix operation, As there
     // are no more double operators. Left also exists. Cases that left is an
     // implicit infix or simple.
-    // Recall: If op is a single implicit node it needs to be omitted!
-    // right = sre.SemanticPred.isOperator(op) ? [left] : [left, op];
-    // op.mathmlTree.setAttribute('AuxiliaryRemoved', true);
-    // right = [left, op]; // .concat(first);
-    // if (!ops.length) {
-    //   return sre.SemanticHeuristics.recurseJuxtaposition_(acc.concat(left), ops, elements);
-    // }
     var newOp = sre.SemanticHeuristics.getInstance().factory.makeBranchNode(
       sre.SemanticAttr.Type.INFIXOP, [left, ops.shift()], [op], op.textContent);
     newOp.role = sre.SemanticAttr.Role.IMPLICIT;
     sre.SemanticHeuristics.run('combine_juxtaposition', newOp);
     ops.unshift(newOp);
     return sre.SemanticHeuristics.recurseJuxtaposition_(acc, ops, elements);
-    // ops.unshift(sre.SemanticProcessor.getInstance()['implicitNode']([left, op, ops.shift()]));
-    // return sre.SemanticHeuristics.recurseJuxtaposition_(acc.concat(right), ops, elements);
   }
   if (sre.SemanticPred.isOperator(left) || sre.SemanticPred.isOperator(right)) {
-    sre.Debugger.getInstance().output('Case 4');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 4');
     return sre.SemanticHeuristics.recurseJuxtaposition_(
       acc.concat([left, op, right]).concat(first), ops, elements);
   }
@@ -502,7 +492,7 @@ sre.SemanticHeuristics.recurseJuxtaposition_ = function(acc, ops, elements) {
   if (sre.SemanticPred.isImplicitOp(left) &&
       sre.SemanticPred.isImplicitOp(right)) {
     // Merge both left and right.
-    sre.Debugger.getInstance().output('Case 5');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 5');
     left.contentNodes.push(op);
     left.contentNodes = left.contentNodes.concat(right.contentNodes);
     left.childNodes.push(right);
@@ -514,7 +504,7 @@ sre.SemanticHeuristics.recurseJuxtaposition_ = function(acc, ops, elements) {
     result = left;
   } else if (sre.SemanticPred.isImplicitOp(left)) {
     // Add to the left one.
-    sre.Debugger.getInstance().output('Case 6');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 6');
     left.contentNodes.push(op);
     left.childNodes.push(right);
     right.parentNode = left;
@@ -524,7 +514,7 @@ sre.SemanticHeuristics.recurseJuxtaposition_ = function(acc, ops, elements) {
     result = left;
   } else if (sre.SemanticPred.isImplicitOp(right)) {
     // Add to the right one.
-    sre.Debugger.getInstance().output('Case 7');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 7');
     right.contentNodes.unshift(op);
     right.childNodes.unshift(left);
     left.parentNode = right;
@@ -534,7 +524,7 @@ sre.SemanticHeuristics.recurseJuxtaposition_ = function(acc, ops, elements) {
     result = right;
   } else {
   // Create new implicit node.
-    sre.Debugger.getInstance().output('Case 8');
+    sre.Debugger.getInstance().output('Juxta Heuristic Case 8');
     result = sre.SemanticHeuristics.getInstance().factory.makeBranchNode(
       sre.SemanticAttr.Type.INFIXOP, [left, right], [op], op.textContent);
     result.role = sre.SemanticAttr.Role.IMPLICIT;

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -199,14 +199,6 @@ sre.SemanticProcessor.prototype.explicitMixed_ = function(nodes) {
   return result.concat(partition.comp[partition.comp.length - 1]);
 };
 
-//   if (sre.SemanticPred.isAttribute('type', 'NUMBER')(node.childNodes[0]) &&
-//       sre.SemanticPred.isAttribute('type', 'FRACTION')(node.childNodes[1])) {
-//     node.type = sre.SemanticAttr.Type.NUMBER;
-//     node.role = sre.SemanticAttr.Role.MIXED;
-//   }
-//   return node;
-// };
-
 
 /**
  * Creates a node of the specified type by collapsing the given node list into
@@ -1757,6 +1749,7 @@ sre.SemanticProcessor.prototype.functionNode_ = function(func, arg) {
     applNode.mathml = appl.mathml;
     applNode.annotation = appl.annotation;
     applNode.attributes = appl.attributes;
+    delete this.funcAppls[func.id];
   }
   applNode.type = sre.SemanticAttr.Type.PUNCTUATION;
   applNode.role = sre.SemanticAttr.Role.APPLICATION;

--- a/src/semantic_tree/semantic_processor.js
+++ b/src/semantic_tree/semantic_processor.js
@@ -47,6 +47,12 @@ sre.SemanticProcessor = function() {
   this.heuristics = sre.SemanticHeuristics.getInstance();
   this.heuristics.factory = this.factory_;
 
+  /**
+   * Table for caching explicit function applications.
+   * @type {Object.<sre.SemanticNode>}
+   */
+  this.funcAppls = {};
+
 };
 goog.addSingletonGetter(sre.SemanticProcessor);
 
@@ -1550,7 +1556,8 @@ sre.SemanticProcessor.classifyFunction_ = function(funcNode, restNodes) {
     //
     // TODO (sorge) This should not be destructive! This in particular destroys
     // any information we get on the element. Eg., texclass=NONE.
-    restNodes.shift();
+    sre.SemanticProcessor.getInstance().funcAppls[funcNode.id] =
+      restNodes.shift();
     var role = sre.SemanticAttr.Role.SIMPLEFUNC;
     if (funcNode.role === sre.SemanticAttr.Role.PREFIXFUNC ||
         funcNode.role === sre.SemanticAttr.Role.LIMFUNC) {
@@ -1742,7 +1749,15 @@ sre.SemanticProcessor.prototype.getIntegralArgs_ = function(nodes, opt_args) {
  */
 sre.SemanticProcessor.prototype.functionNode_ = function(func, arg) {
   var applNode = sre.SemanticProcessor.getInstance().factory_.makeContentNode(
-      sre.SemanticAttr.functionApplication());
+        sre.SemanticAttr.functionApplication());
+  var appl = this.funcAppls[func.id];
+  if (appl) {
+    // TODO: Work out why we cannot just take appl.
+    applNode.mathmlTree = appl.mathmlTree;
+    applNode.mathml = appl.mathml;
+    applNode.annotation = appl.annotation;
+    applNode.attributes = appl.attributes;
+  }
   applNode.type = sre.SemanticAttr.Type.PUNCTUATION;
   applNode.role = sre.SemanticAttr.Role.APPLICATION;
   var funcop = sre.SemanticProcessor.getFunctionOp_(

--- a/src/walker/rebuild_stree.js
+++ b/src/walker/rebuild_stree.js
@@ -121,7 +121,7 @@ sre.RebuildStree.prototype.assembleTree = function(node) {
     return snode;
   }
   if (content.length > 0) {
-    var fcontent = sre.WalkerUtil.getBySemanticId(node, content[0]);
+    var fcontent = sre.WalkerUtil.getBySemanticId(this.mathml, content[0]);
     if (fcontent) {
       var operator = sre.WalkerUtil.splitAttribute(
           sre.WalkerUtil.getAttribute(
@@ -132,7 +132,7 @@ sre.RebuildStree.prototype.assembleTree = function(node) {
     }
   }
   var setParent = function(n) {
-    var mml = sre.WalkerUtil.getBySemanticId(node, n);
+    var mml = sre.WalkerUtil.getBySemanticId(this.mathml, n);
     var sn = this.assembleTree(mml);
     sn.parent = snode;
     return sn;


### PR DESCRIPTION
This fixes odds and ends stemming from releasing the new juxtaposition heuristics into the wild. 
* Correct issue of implicit operations becoming operators themselves.
* Optimises ordering of invisible times.
* Systematic treatment of multiple invisible times similar to regular pre/post fix operations.
* Ensures correct ordering for enrichment, while retaining sub positions in tree elements

Along the way it fixes some longstanding issues and general problems:
* Solution for destructive dropping of explicit function applications. 
* Ensures that only func apps that are newly introduced will be marked as added.
* Robust rebuilding of semantic tree, regardless of tree order of mml nodes.
* Fixes nearly all cases where enrichment might lead to orphaned child nodes. There is still a minor issues with paddings, see test `Wrappers_1`.

