### PR TITLE
Adds a refocus method for walkers.

### DIFF
--- a/src/walker/abstract_walker.js
+++ b/src/walker/abstract_walker.js
@@ -889,3 +889,20 @@ sre.AbstractWalker.prototype.previousRules = function() {
   this.moved = sre.Walker.move.REPEAT;
   return this.getFocus().clone();
 };
+
+
+/**
+ * Refocuses in case levels have been altered outside the walker's control.
+ */
+sre.AbstractWalker.prototype.refocus = function() {
+  var focus = this.getFocus();
+  while (!focus.getNodes().length) {
+    var last = this.levels.peek();
+    var up = this.up();
+    if (!up) break;
+    this.setFocus(up);
+    focus = this.getFocus(true);
+  }
+  this.levels.push(last);
+  this.setFocus(focus);
+};


### PR DESCRIPTION
Adds refocus method to the walkers in case the node structure has been altered outside the control of the walker, e.g., by collapsing a node via mouse click.
This solves the issue mentioned in [Mathjax PR 683](https://github.com/mathjax/MathJax-src/pull/683)