### PR TITLE
Refactor Engine options

### DIFF
--- a/ts/audio/abstract_audio_renderer.ts
+++ b/ts/audio/abstract_audio_renderer.ts
@@ -44,7 +44,7 @@ export abstract class AbstractAudioRenderer implements AudioRenderer {
    */
   public get separator() {
     // TODO: (Span) Do this via setSeparator.
-    return Engine.getInstance().modality === 'braille' ? '' : this.separator_;
+    return Engine.getInstance().options.modality === 'braille' ? '' : this.separator_;
   }
 
   /**

--- a/ts/audio/audio_util.ts
+++ b/ts/audio/audio_util.ts
@@ -182,7 +182,7 @@ export function personalityMarkup(descrs: AuditoryDescription[]): Markup[] {
   }
   result = result.concat(finaliseMarkup_());
   result = simplifyMarkup_(result);
-  result = Engine.getInstance().cleanpause ? cleanPause(result) : result;
+  result = Engine.getInstance().options.cleanpause ? cleanPause(result) : result;
   return result;
 }
 

--- a/ts/audio/aural_rendering.ts
+++ b/ts/audio/aural_rendering.ts
@@ -48,7 +48,7 @@ const renderers: Map<EngineConst.Markup, AudioRenderer> = new Map([
  * @override
  */
 export function setSeparator(sep: string) {
-  const renderer = renderers.get(Engine.getInstance().markup);
+  const renderer = renderers.get(Engine.getInstance().options.markup);
   if (renderer) {
     renderer.separator = sep;
   }
@@ -58,7 +58,7 @@ export function setSeparator(sep: string) {
  * @override
  */
 export function getSeparator() {
-  const renderer = renderers.get(Engine.getInstance().markup);
+  const renderer = renderers.get(Engine.getInstance().options.markup);
   return renderer ? renderer.separator : '';
 }
 
@@ -66,7 +66,7 @@ export function getSeparator() {
  * @override
  */
 export function markup(descrs: AuditoryDescription[]) {
-  const renderer = renderers.get(Engine.getInstance().markup);
+  const renderer = renderers.get(Engine.getInstance().options.markup);
   if (!renderer) {
     return '';
   }
@@ -81,7 +81,7 @@ export function merge(strs: (Span | string)[]) {
   const span = strs.map((s) => {
     return typeof s === 'string' ? Span.stringEmpty(s) : s;
   });
-  const renderer = renderers.get(Engine.getInstance().markup);
+  const renderer = renderers.get(Engine.getInstance().options.markup);
   if (!renderer) {
     return strs.join();
   }
@@ -92,7 +92,7 @@ export function merge(strs: (Span | string)[]) {
  * @override
  */
 export function finalize(str: string) {
-  const renderer = renderers.get(Engine.getInstance().markup);
+  const renderer = renderers.get(Engine.getInstance().options.markup);
   if (!renderer) {
     return str;
   }
@@ -103,7 +103,7 @@ export function finalize(str: string) {
  * @override
  */
 export function error(key: string) {
-  const renderer = renderers.get(Engine.getInstance().markup);
+  const renderer = renderers.get(Engine.getInstance().options.markup);
   if (!renderer) {
     return '';
   }
@@ -129,5 +129,5 @@ export function registerRenderer(
  * @returns True if it is an instance of the given type.
  */
 export function isXml(): boolean {
-  return renderers.get(Engine.getInstance().markup) instanceof XmlRenderer;
+  return renderers.get(Engine.getInstance().options.markup) instanceof XmlRenderer;
 }

--- a/ts/audio/layout_renderer.ts
+++ b/ts/audio/layout_renderer.ts
@@ -28,8 +28,8 @@ import { XmlRenderer } from './xml_renderer.js';
 
 export class LayoutRenderer extends XmlRenderer {
   public static options = {
-    cayleyshort: Engine.getInstance().cayleyshort,
-    linebreaks: Engine.getInstance().linebreaks
+    cayleyshort: Engine.getInstance().options.cayleyshort,
+    linebreaks: Engine.getInstance().options.linebreaks
   };
 
   /**
@@ -508,7 +508,7 @@ function handleCayley(cayley: Element): string {
     height: 1,
     sep: mat[0].sep
   };
-  if (Engine.getInstance().cayleyshort && mat[0].cells[0] === '⠀') {
+  if (Engine.getInstance().options.cayleyshort && mat[0].cells[0] === '⠀') {
     bar.cells[0] = '⠀';
   }
   mat.splice(1, 0, bar);
@@ -627,7 +627,7 @@ function handleFractionPart(prt: Element): string {
  * @returns A markup string with the correct linebreaking value.
  */
 function handleRelation(rel: Element): string {
-  if (!Engine.getInstance().linebreaks) {
+  if (!Engine.getInstance().options.linebreaks) {
     return recurseTree(rel);
   }
   const value = relValues.get(parseInt(rel.getAttribute('value')));

--- a/ts/audio/ssml_renderer.ts
+++ b/ts/audio/ssml_renderer.ts
@@ -35,7 +35,7 @@ export class SsmlRenderer extends XmlRenderer {
     return (
       '<?xml version="1.0"?><speak version="1.1"' +
       ' xmlns="http://www.w3.org/2001/10/synthesis"' +
-      ` xml:lang="${Engine.getInstance().locale}">` +
+      ` xml:lang="${Engine.getInstance().options.locale}">` +
       '<prosody rate="' +
       Engine.getInstance().getRate() +
       '%">' +
@@ -112,9 +112,9 @@ export class SsmlRenderer extends XmlRenderer {
       const span = spans[i];
       if (this.isEmptySpan(span)) continue;
       const kind = SsmlRenderer.MARK_KIND ? span.attributes['kind'] : '';
-      const id = Engine.getInstance().automark
+      const id = Engine.getInstance().options.automark
         ? span.attributes['id']
-        : Engine.getInstance().mark
+        : Engine.getInstance().options.mark
           ? span.attributes['extid']
           : '';
       // TODO:
@@ -132,7 +132,7 @@ export class SsmlRenderer extends XmlRenderer {
         SsmlRenderer.MARKS[id] = true;
       }
       if (
-        Engine.getInstance().character &&
+        Engine.getInstance().options.character &&
         span.speech.length === 1 &&
         span.speech.match(/[a-zA-Z]/)
       ) {

--- a/ts/audio/string_renderer.ts
+++ b/ts/audio/string_renderer.ts
@@ -59,7 +59,7 @@ export class CountingRenderer extends StringRenderer {
   public finalize(str: string): string {
     const output = super.finalize(str);
     const count =
-      Engine.getInstance().modality === 'braille' ? '⣿⠀⣿⠀⣿⠀⣿⠀⣿⠀' : '0123456789';
+      Engine.getInstance().options.modality === 'braille' ? '⣿⠀⣿⠀⣿⠀⣿⠀⣿⠀' : '0123456789';
     let second = new Array(Math.trunc(output.length / 10) + 1).join(count);
     second += count.slice(0, output.length % 10);
     return output + '\n' + second;

--- a/ts/common/dom_util.ts
+++ b/ts/common/dom_util.ts
@@ -83,7 +83,7 @@ export function parseInput(input: string): Element {
 
 // let extIdCount = 0;
 // function addMarkers(node: Element) {
-//   if (Engine.getInstance().automark && tagName(node) !== 'STREE') {
+//   if (Engine.getInstance().options.automark && tagName(node) !== 'STREE') {
 //     extIdCount = 0;
 //     addExtId(node);
 //   }

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -286,6 +286,14 @@ export class Engine {
     return Object.assign({'mode': this.mode}, this.options.json());
   }
 
+  /**
+   * Reset the engine options. This excludes computed elements like mode,
+   * comparators etc.
+   */
+  public reset() {
+    this.options = new Options();
+  }
+
 }
 
 /**

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -22,6 +22,7 @@
 import { AuditoryDescription } from '../audio/auditory_description.js';
 import * as Dcstr from '../rule_engine/dynamic_cstr.js';
 import * as EngineConst from './engine_const.js';
+import * as FileUtil from './file_util.js';
 import { SystemExternal } from './system_external.js';
 
 import { Debugger } from './debugger.js';
@@ -262,14 +263,34 @@ export class Engine {
    */
   public setup(feature: { [key: string]: boolean | string }) {
     ensureDomain(feature);
-    const options = this.options;
     // Setting mode first!
     if (typeof feature['mode'] !== 'undefined') {
       this.mode = feature['mode'] as EngineConst.Mode;
     }
     this.configurate(feature);
-    options.set(feature);
+    this.options.set(feature);
+    if (feature.json) {
+      SystemExternal.jsonPath = FileUtil.makePath(feature.json as string);
+    }
+    if (feature.xpath) {
+      SystemExternal.WGXpath = feature.xpath as string;
+    }
     this.setCustomLoader(feature.custom);
+  }
+
+  /**
+   * Query the engine setup.
+   *
+   * @returns Overview of engine setup as a JSON dictionary.
+   */
+  public json(): { [key: string]: boolean | string } {
+    const features: { [key: string]: string | boolean } = {'mode': this.mode};
+    const engineFeatures = [].concat(
+      Options.STRING_FEATURES,
+      Options.BINARY_FEATURES
+    );
+    engineFeatures.forEach(x => features[x] = (this.options as any)[x]);
+    return features;
   }
 
 }

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -189,7 +189,7 @@ export class Engine {
         if (Dcstr.DynamicCstr.DEFAULT_ORDER.indexOf(feature) !== -1) {
           const value = opt_dynamic[feature];
           // TODO (TS): Make these features cleaner.
-          (this as any)[feature] = value;
+          (this.options as any)[feature] = value;
         }
       }
     }

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -26,6 +26,7 @@ import { SystemExternal } from './system_external.js';
 
 import { Debugger } from './debugger.js';
 import { Variables } from './variables.js';
+import { Options } from './options.js';
 
 declare const SREfeature: { [key: string]: any };
 
@@ -55,40 +56,12 @@ export class SREError extends Error {
  *
  */
 export class Engine {
+  public options: Options = new Options();
+  
   /**
-   * Binary feature vector.
+   * True if configuration block has been applied in HTTP mode.
    */
-  public static BINARY_FEATURES: string[] = [
-    'automark',
-    'mark',
-    'character',
-    'cleanpause',
-    'strict',
-    'structure',
-    'aria',
-    'pprint',
-    'cayleyshort',
-    'linebreaks'
-  ];
-
-  /**
-   * String feature vector.
-   */
-  public static STRING_FEATURES: string[] = [
-    'markup',
-    'style',
-    'domain',
-    'speech',
-    'walker',
-    'defaultLocale',
-    'locale',
-    'delay',
-    'modality',
-    'rate',
-    'rules',
-    'subiso',
-    'prune'
-  ];
+  public config = false;
 
   // TODO (TS): Keeping this as a singleton for the time being.
   private static instance: Engine;
@@ -120,29 +93,14 @@ export class Engine {
   public init = true;
 
   /**
-   * Delay flag, to avoid auto setup of engine.
-   */
-  public delay = false;
-
-  /**
    * Maps domains to comparators.
    */
   public comparators: { [key: string]: () => Dcstr.Comparator } = {};
 
   /**
-   * Current domain.
-   */
-  public domain = 'mathspeak';
-
-  /**
-   * Current style.
-   */
-  public style = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.STYLE];
-
-  /**
    * The default locale.
    */
-  public _defaultLocale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
+  private _defaultLocale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
 
   /**
    * Sets the default locale for SRE.
@@ -159,74 +117,6 @@ export class Engine {
   }
 
   /**
-   * Current locale.
-   */
-  public locale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
-
-  /**
-   * Current subiso for the locale.
-   */
-  public subiso = '';
-
-  /**
-   * Current modality.
-   */
-  public modality = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.MODALITY];
-
-  /**
-   * The level to which speech attributes are added to enriched elements
-   * (none, shallow, deep).
-   */
-  public speech: EngineConst.Speech = EngineConst.Speech.NONE;
-
-  /**
-   * Caching during speech generation.
-   */
-  public markup: EngineConst.Markup = EngineConst.Markup.NONE;
-
-  // Markup options
-  public mark = true;
-  /**
-   * Automatic marking of elements for spans.
-   */
-  public automark = false;
-  public character = true;
-  public cleanpause = true;
-
-  /**
-   * Nemeth layout options
-   */
-  public cayleyshort = true;
-  public linebreaks = false;
-
-  /**
-   * Percentage of default rate used by external TTS. This can be used to scale
-   * pauses.
-   */
-  public rate = '100';
-
-  /**
-   * Current walker mode.
-   */
-  public walker = 'Table';
-
-  /**
-   * Indicates if skeleton structure attributes are added to enriched elements
-   */
-  public structure = false;
-  public aria = false;
-
-  /**
-   * List of rule sets given as the constructor functions.
-   */
-  public ruleSets: string[] = [];
-
-  /**
-   * Strict interpretations of rules and constraints.
-   */
-  public strict = false;
-
-  /**
    * Current browser is MS Internet Explorer but not Edge.
    */
   public isIE = false;
@@ -235,26 +125,6 @@ export class Engine {
    * Current browser is MS Edge.
    */
   public isEdge = false;
-
-  /**
-   * Pretty Print mode.
-   */
-  public pprint = false;
-
-  /**
-   * True if configuration block has been applied in HTTP mode.
-   */
-  public config = false;
-
-  /**
-   * Rules file to load.
-   */
-  public rules = '';
-
-  /**
-   * EngineConstraints to prune given dot separated.
-   */
-  public prune = '';
 
   /**
    * @returns The Engine object.
@@ -296,7 +166,7 @@ export class Engine {
    * @returns The current base rate.
    */
   public getRate(): number {
-    const numeric = parseInt(this.rate, 10);
+    const numeric = parseInt(this.options.rate, 10);
     return isNaN(numeric) ? 100 : numeric;
   }
 
@@ -323,8 +193,8 @@ export class Engine {
         }
       }
     }
-    EngineConst.DOMAIN_TO_STYLES[this.domain] = this.style;
-    const dynamic = [this.locale, this.modality, this.domain, this.style].join(
+    EngineConst.DOMAIN_TO_STYLES[this.options.domain] = this.options.style;
+    const dynamic = [this.options.locale, this.options.modality, this.options.domain, this.options.style].join(
       '.'
     );
     const fallback = Dcstr.DynamicProperties.createProp(
@@ -333,8 +203,8 @@ export class Engine {
       [Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.DOMAIN]],
       [Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.STYLE]]
     );
-    const comparator = this.comparators[this.domain];
-    const parser = this.parsers[this.domain];
+    const comparator = this.comparators[this.options.domain];
+    const parser = this.parsers[this.options.domain];
     this.parser = parser ? parser : this.defaultParser;
     this.dynamicCstr = this.parser.parse(dynamic);
     this.dynamicCstr.updateProperties(fallback.getProperties());
@@ -347,7 +217,7 @@ export class Engine {
    * Private constructor.
    */
   private constructor() {
-    this.locale = this.defaultLocale;
+    this.options.locale = this.defaultLocale;
     this.evaluator = Engine.defaultEvaluator;
     this.defaultParser = new Dcstr.DynamicCstrParser(
       Dcstr.DynamicCstr.DEFAULT_ORDER
@@ -441,7 +311,7 @@ export class EnginePromise {
    * @returns The promise for a locale.
    */
   public static get(
-    locale: string = Engine.getInstance().locale
+    locale: string = Engine.getInstance().options.locale
   ): Promise<string> {
     return EnginePromise.promises[locale] || Promise.resolve('');
   }

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -284,9 +284,7 @@ export class Engine {
    * @returns Overview of engine setup as a JSON dictionary.
    */
   public json(): { [key: string]: boolean | string } {
-    const features: { [key: string]: string | boolean } = this.options.json();
-    features['mode'] = this.mode;
-    return features;
+    return Object.assign({'mode': this.mode}, this.options.json());
   }
 
 }
@@ -388,7 +386,7 @@ function ensureDomain(feature: { [key: string]: boolean | string }) {
   ) {
     return;
   }
-  if (!feature.domain) {
+  if (!feature.domain && !feature.locale) {
     return;
   }
   if (feature.domain === 'default') {
@@ -396,11 +394,9 @@ function ensureDomain(feature: { [key: string]: boolean | string }) {
     return;
   }
   const locale = (feature.locale || Engine.getInstance().options.locale) as string;
-  const domain = feature.domain as string;
-  if (MATHSPEAK_ONLY.indexOf(locale) !== -1) {
-    if (domain !== 'mathspeak') {
-      feature.domain = 'mathspeak';
-    }
+  const domain = (feature.domain || Engine.getInstance().options.domain) as string;
+  if (MATHSPEAK_ONLY.indexOf(locale) !== -1 && domain !== 'mathspeak') {
+    feature.domain = 'mathspeak';
     return;
   }
   if (locale === 'en') {

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -262,7 +262,6 @@ export class Engine {
    * @param feature An object describing some setup features.
    */
   public setup(feature: { [key: string]: boolean | string }) {
-    ensureDomain(feature);
     // Setting mode first!
     if (typeof feature['mode'] !== 'undefined') {
       this.mode = feature['mode'] as EngineConst.Mode;
@@ -358,55 +357,3 @@ export class EnginePromise {
   }
 
 }
-
-const MATHSPEAK_ONLY: string[] = ['ca', 'da', 'es'];
-
-const EN_RULES: string[] = [
-  'chromevox',
-  'clearspeak',
-  'mathspeak',
-  'emacspeak',
-  'html'
-];
-
-/**
- * Ensures that the domain and preference/style combination in a given feature
- * vector actually exists.
- *
- * @param feature The current SRE feature vector.
- */
-function ensureDomain(feature: { [key: string]: boolean | string }) {
-  // This preserves the possibility to specify default as domain.
-  // < 3.2  this lead to the use of chromevox rules in English.
-  // >= 3.2 this defaults to Mathspeak. It also ensures that in other locales
-  // we get a meaningful output.
-  if (
-    (feature.modality && feature.modality !== 'speech') ||
-    (!feature.modality && Engine.getInstance().options.modality !== 'speech')
-  ) {
-    return;
-  }
-  if (!feature.domain && !feature.locale) {
-    return;
-  }
-  if (feature.domain === 'default') {
-    feature.domain = 'mathspeak';
-    return;
-  }
-  const locale = (feature.locale || Engine.getInstance().options.locale) as string;
-  const domain = (feature.domain || Engine.getInstance().options.domain) as string;
-  if (MATHSPEAK_ONLY.indexOf(locale) !== -1 && domain !== 'mathspeak') {
-    feature.domain = 'mathspeak';
-    return;
-  }
-  if (locale === 'en') {
-    if (EN_RULES.indexOf(domain) === -1) {
-      feature.domain = 'mathspeak';
-    }
-    return;
-  }
-  if (domain !== 'mathspeak' && domain !== 'clearspeak') {
-    feature.domain = 'mathspeak';
-  }
-}
-

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -56,6 +56,7 @@ export class SREError extends Error {
  *
  */
 export class Engine {
+
   public options: Options = new Options();
   
   /**
@@ -253,6 +254,24 @@ export class Engine {
       this.customLoader = fn;
     }
   }
+
+  /**
+   * Method to setup the basic engine parameters and options.
+   *
+   * @param feature An object describing some setup features.
+   */
+  public setup(feature: { [key: string]: boolean | string }) {
+    ensureDomain(feature);
+    const options = this.options;
+    // Setting mode first!
+    if (typeof feature['mode'] !== 'undefined') {
+      this.mode = feature['mode'] as EngineConst.Mode;
+    }
+    this.configurate(feature);
+    options.set(feature);
+    this.setCustomLoader(feature.custom);
+  }
+
 }
 
 /**
@@ -322,4 +341,59 @@ export class EnginePromise {
   public static getall() {
     return Promise.all(Object.values(EnginePromise.promises));
   }
+
 }
+
+const MATHSPEAK_ONLY: string[] = ['ca', 'da', 'es'];
+
+const EN_RULES: string[] = [
+  'chromevox',
+  'clearspeak',
+  'mathspeak',
+  'emacspeak',
+  'html'
+];
+
+/**
+ * Ensures that the domain and preference/style combination in a given feature
+ * vector actually exists.
+ *
+ * @param feature The current SRE feature vector.
+ */
+function ensureDomain(feature: { [key: string]: boolean | string }) {
+  // This preserves the possibility to specify default as domain.
+  // < 3.2  this lead to the use of chromevox rules in English.
+  // >= 3.2 this defaults to Mathspeak. It also ensures that in other locales
+  // we get a meaningful output.
+  if (
+    (feature.modality && feature.modality !== 'speech') ||
+    (!feature.modality && Engine.getInstance().options.modality !== 'speech')
+  ) {
+    return;
+  }
+  if (!feature.domain) {
+    return;
+  }
+  if (feature.domain === 'default') {
+    feature.domain = 'mathspeak';
+    return;
+  }
+  const locale = (feature.locale || Engine.getInstance().options.locale) as string;
+  const domain = feature.domain as string;
+  if (MATHSPEAK_ONLY.indexOf(locale) !== -1) {
+    if (domain !== 'mathspeak') {
+      feature.domain = 'mathspeak';
+    }
+    return;
+  }
+  if (locale === 'en') {
+    if (EN_RULES.indexOf(domain) === -1) {
+      feature.domain = 'mathspeak';
+    }
+    return;
+  }
+  if (domain !== 'mathspeak' && domain !== 'clearspeak') {
+    feature.domain = 'mathspeak';
+  }
+}
+

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -284,12 +284,8 @@ export class Engine {
    * @returns Overview of engine setup as a JSON dictionary.
    */
   public json(): { [key: string]: boolean | string } {
-    const features: { [key: string]: string | boolean } = {'mode': this.mode};
-    const engineFeatures = [].concat(
-      Options.STRING_FEATURES,
-      Options.BINARY_FEATURES
-    );
-    engineFeatures.forEach(x => features[x] = (this.options as any)[x]);
+    const features: { [key: string]: string | boolean } = this.options.json();
+    features['mode'] = this.mode;
     return features;
   }
 

--- a/ts/common/engine_const.ts
+++ b/ts/common/engine_const.ts
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 /**
- * @file Basic parameter values for the Engine.
+ * @file Basic constants and enums for the Engine that should never change.
  * @author volker.sorge@gmail.com (Volker Sorge)
  */
 

--- a/ts/common/engine_setup.ts
+++ b/ts/common/engine_setup.ts
@@ -23,6 +23,7 @@ import * as MathMap from '../speech_rules/math_map.js';
 import * as BrowserUtil from './browser_util.js';
 import { Debugger } from './debugger.js';
 import { Engine, EnginePromise } from './engine.js';
+import { Options } from './options.js';
 import * as FileUtil from './file_util.js';
 import { SystemExternal } from './system_external.js';
 
@@ -49,7 +50,7 @@ function ensureDomain(feature: { [key: string]: boolean | string }) {
   // we get a meaningful output.
   if (
     (feature.modality && feature.modality !== 'speech') ||
-    (!feature.modality && Engine.getInstance().modality !== 'speech')
+    (!feature.modality && Engine.getInstance().options.modality !== 'speech')
   ) {
     return;
   }
@@ -60,7 +61,7 @@ function ensureDomain(feature: { [key: string]: boolean | string }) {
     feature.domain = 'mathspeak';
     return;
   }
-  const locale = (feature.locale || Engine.getInstance().locale) as string;
+  const locale = (feature.locale || Engine.getInstance().options.locale) as string;
   const domain = feature.domain as string;
   if (MATHSPEAK_ONLY.indexOf(locale) !== -1) {
     if (domain !== 'mathspeak') {
@@ -91,21 +92,22 @@ function ensureDomain(feature: { [key: string]: boolean | string }) {
  */
 export async function setup(feature: { [key: string]: boolean | string }) {
   ensureDomain(feature);
-  const engine = Engine.getInstance() as any;
+  const engine = Engine.getInstance();
+  const options = engine.options as any;
   const setIf = (feat: string) => {
     if (typeof feature[feat] !== 'undefined') {
-      engine[feat] = !!feature[feat];
+      options[feat] = !!feature[feat];
     }
   };
   const setMulti = (feat: string) => {
     if (typeof feature[feat] !== 'undefined') {
-      engine[feat] = feature[feat];
+      options[feat] = feature[feat];
     }
   };
   setMulti('mode');
   engine.configurate(feature);
-  Engine.BINARY_FEATURES.forEach(setIf);
-  Engine.STRING_FEATURES.forEach(setMulti);
+  Options.BINARY_FEATURES.forEach(setIf);
+  Options.STRING_FEATURES.forEach(setMulti);
   if (feature.debug) {
     Debugger.getInstance().init();
   }
@@ -129,8 +131,8 @@ export async function setup(feature: { [key: string]: boolean | string }) {
     engine.init = false;
     return EnginePromise.get();
   }
-  if (engine.delay) {
-    engine.delay = false;
+  if (options.delay) {
+    options.delay = false;
     return EnginePromise.get();
   }
   return MathMap.loadLocale();

--- a/ts/common/engine_setup.ts
+++ b/ts/common/engine_setup.ts
@@ -21,10 +21,8 @@
 import * as L10n from '../l10n/l10n.js';
 import * as MathMap from '../speech_rules/math_map.js';
 import * as BrowserUtil from './browser_util.js';
-import { Options } from './options.js';
 import { Debugger } from './debugger.js';
 import { Engine, EnginePromise } from './engine.js';
-import * as FileUtil from './file_util.js';
 import { SystemExternal } from './system_external.js';
 
 // Engine setup method.
@@ -38,17 +36,11 @@ import { SystemExternal } from './system_external.js';
  * @returns The promise that resolves once setup is complete.
  */
 export async function setupEngine(feature: { [key: string]: boolean | string }) {
-  const engine = Engine.getInstance();
-  engine.setup(feature);
   if (feature.debug) {
     Debugger.getInstance().init();
   }
-  if (feature.json) {
-    SystemExternal.jsonPath = FileUtil.makePath(feature.json as string);
-  }
-  if (feature.xpath) {
-    SystemExternal.WGXpath = feature.xpath as string;
-  }
+  const engine = Engine.getInstance();
+  engine.setup(feature);
   setupBrowsers(engine);
   L10n.setLocale();
   engine.setDynamicCstr();
@@ -87,16 +79,7 @@ function setupBrowsers(engine: Engine) {
  *     values.
  */
 export function engineSetup(): { [key: string]: boolean | string } {
-  const engineFeatures = [].concat(
-    Options.STRING_FEATURES,
-    Options.BINARY_FEATURES
-  );
-  const engine = Engine.getInstance() as any;
-  const features: { [key: string]: string | boolean } = {};
-  features['mode'] = engine.mode;
-  engineFeatures.forEach(function (x) {
-    features[x] = engine.options[x];
-  });
+  const features: { [key: string]: string | boolean } = Engine.getInstance().json();
   features.json = SystemExternal.jsonPath;
   features.xpath = SystemExternal.WGXpath;
   return features;

--- a/ts/common/engine_setup.ts
+++ b/ts/common/engine_setup.ts
@@ -21,65 +21,11 @@
 import * as L10n from '../l10n/l10n.js';
 import * as MathMap from '../speech_rules/math_map.js';
 import * as BrowserUtil from './browser_util.js';
+import { Options } from './options.js';
 import { Debugger } from './debugger.js';
 import { Engine, EnginePromise } from './engine.js';
-import { Mode } from './engine_const.js';
-import { Options } from './options.js';
 import * as FileUtil from './file_util.js';
 import { SystemExternal } from './system_external.js';
-
-const MATHSPEAK_ONLY: string[] = ['ca', 'da', 'es'];
-
-const EN_RULES: string[] = [
-  'chromevox',
-  'clearspeak',
-  'mathspeak',
-  'emacspeak',
-  'html'
-];
-
-/**
- * Ensures that the domain and preference/style combination in a given feature
- * vector actually exists.
- *
- * @param feature The current SRE feature vector.
- */
-function ensureDomain(feature: { [key: string]: boolean | string }) {
-  // This preserves the possibility to specify default as domain.
-  // < 3.2  this lead to the use of chromevox rules in English.
-  // >= 3.2 this defaults to Mathspeak. It also ensures that in other locales
-  // we get a meaningful output.
-  if (
-    (feature.modality && feature.modality !== 'speech') ||
-    (!feature.modality && Engine.getInstance().options.modality !== 'speech')
-  ) {
-    return;
-  }
-  if (!feature.domain) {
-    return;
-  }
-  if (feature.domain === 'default') {
-    feature.domain = 'mathspeak';
-    return;
-  }
-  const locale = (feature.locale || Engine.getInstance().options.locale) as string;
-  const domain = feature.domain as string;
-  if (MATHSPEAK_ONLY.indexOf(locale) !== -1) {
-    if (domain !== 'mathspeak') {
-      feature.domain = 'mathspeak';
-    }
-    return;
-  }
-  if (locale === 'en') {
-    if (EN_RULES.indexOf(domain) === -1) {
-      feature.domain = 'mathspeak';
-    }
-    return;
-  }
-  if (domain !== 'mathspeak' && domain !== 'clearspeak') {
-    feature.domain = 'mathspeak';
-  }
-}
 
 // Engine setup method.
 
@@ -91,27 +37,9 @@ function ensureDomain(feature: { [key: string]: boolean | string }) {
  * @param feature An object describing some setup features.
  * @returns The promise that resolves once setup is complete.
  */
-export async function setup(feature: { [key: string]: boolean | string }) {
-  ensureDomain(feature);
+export async function setupEngine(feature: { [key: string]: boolean | string }) {
   const engine = Engine.getInstance();
-  const options = engine.options as any;
-  const setIf = (feat: string) => {
-    if (typeof feature[feat] !== 'undefined') {
-      options[feat] = !!feature[feat];
-    }
-  };
-  const setMulti = (feat: string) => {
-    if (typeof feature[feat] !== 'undefined') {
-      options[feat] = feature[feat];
-    }
-  };
-  // Setting mode first!
-  if (typeof feature['mode'] !== 'undefined') {
-    engine.mode = feature['mode'] as Mode;
-  }
-  engine.configurate(feature);
-  Options.BINARY_FEATURES.forEach(setIf);
-  Options.STRING_FEATURES.forEach(setMulti);
+  engine.setup(feature);
   if (feature.debug) {
     Debugger.getInstance().init();
   }
@@ -121,7 +49,6 @@ export async function setup(feature: { [key: string]: boolean | string }) {
   if (feature.xpath) {
     SystemExternal.WGXpath = feature.xpath as string;
   }
-  engine.setCustomLoader(feature.custom);
   setupBrowsers(engine);
   L10n.setLocale();
   engine.setDynamicCstr();
@@ -135,8 +62,8 @@ export async function setup(feature: { [key: string]: boolean | string }) {
     engine.init = false;
     return EnginePromise.get();
   }
-  if (options.delay) {
-    options.delay = false;
+  if (engine.options.delay) {
+    engine.options.delay = false;
     return EnginePromise.get();
   }
   return MathMap.loadLocale();
@@ -152,3 +79,26 @@ function setupBrowsers(engine: Engine) {
   engine.isIE = BrowserUtil.detectIE();
   engine.isEdge = BrowserUtil.detectEdge();
 }
+
+/**
+ * Query the engine setup.
+ *
+ * @returns Object vector with all engine feature
+ *     values.
+ */
+export function engineSetup(): { [key: string]: boolean | string } {
+  const engineFeatures = [].concat(
+    Options.STRING_FEATURES,
+    Options.BINARY_FEATURES
+  );
+  const engine = Engine.getInstance() as any;
+  const features: { [key: string]: string | boolean } = {};
+  features['mode'] = engine.mode;
+  engineFeatures.forEach(function (x) {
+    features[x] = engine.options[x];
+  });
+  features.json = SystemExternal.jsonPath;
+  features.xpath = SystemExternal.WGXpath;
+  return features;
+}
+

--- a/ts/common/engine_setup.ts
+++ b/ts/common/engine_setup.ts
@@ -23,6 +23,7 @@ import * as MathMap from '../speech_rules/math_map.js';
 import * as BrowserUtil from './browser_util.js';
 import { Debugger } from './debugger.js';
 import { Engine, EnginePromise } from './engine.js';
+import { Mode } from './engine_const.js';
 import { Options } from './options.js';
 import * as FileUtil from './file_util.js';
 import { SystemExternal } from './system_external.js';
@@ -104,7 +105,10 @@ export async function setup(feature: { [key: string]: boolean | string }) {
       options[feat] = feature[feat];
     }
   };
-  setMulti('mode');
+  // Setting mode first!
+  if (typeof feature['mode'] !== 'undefined') {
+    engine.mode = feature['mode'] as Mode;
+  }
   engine.configurate(feature);
   Options.BINARY_FEATURES.forEach(setIf);
   Options.STRING_FEATURES.forEach(setMulti);

--- a/ts/common/options.ts
+++ b/ts/common/options.ts
@@ -3,7 +3,7 @@
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// You may tain a copy of the License at
 //
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
@@ -151,5 +151,18 @@ export class Options {
    * EngineConstraints to prune given dot separated.
    */
   public prune = '';
+
+  constructor(options: {[key: string]: boolean | string} = {}) {
+    this.set(options);
+  }
+
+  set(options: {[key: string]: boolean | string}) {
+    for (const [option, value] of Object.entries(options)) {
+      if (Options.BINARY_FEATURES.includes(option) || Options.STRING_FEATURES.includes(option)) {
+        (this as any)[option] = value;
+        continue;
+      }
+    }
+  }
 
 }

--- a/ts/common/options.ts
+++ b/ts/common/options.ts
@@ -157,6 +157,7 @@ export class Options {
   }
 
   set(options: {[key: string]: boolean | string}) {
+    this.ensureDomain(options);
     for (const [option, value] of Object.entries(options)) {
       if (Options.BINARY_FEATURES.includes(option) || Options.STRING_FEATURES.includes(option)) {
         (this as any)[option] = value;
@@ -175,4 +176,55 @@ export class Options {
     return features;
   }
 
+  /**
+   * Ensures that the domain and preference/style combination in a given feature
+   * vector actually exists.
+   *
+   * @param feature The current SRE feature vector.
+   */
+  private ensureDomain(feature: { [key: string]: boolean | string }) {
+    // This preserves the possibility to specify default as domain.
+    // < 3.2  this lead to the use of chromevox rules in English.
+    // >= 3.2 this defaults to Mathspeak. It also ensures that in other locales
+    // we get a meaningful output.
+    if (
+      (feature.modality && feature.modality !== 'speech') ||
+        (!feature.modality && this.modality !== 'speech')
+    ) {
+      return;
+    }
+    if (!feature.domain && !feature.locale) {
+      return;
+    }
+    if (feature.domain === 'default') {
+      feature.domain = 'mathspeak';
+      return;
+    }
+    const locale = (feature.locale || this.locale) as string;
+    const domain = (feature.domain || this.domain) as string;
+    if (MATHSPEAK_ONLY.indexOf(locale) !== -1 && domain !== 'mathspeak') {
+      feature.domain = 'mathspeak';
+      return;
+    }
+    if (locale === 'en') {
+      if (EN_RULES.indexOf(domain) === -1) {
+        feature.domain = 'mathspeak';
+      }
+      return;
+    }
+    if (domain !== 'mathspeak' && domain !== 'clearspeak') {
+      feature.domain = 'mathspeak';
+    }
+  }
+
 }
+
+const MATHSPEAK_ONLY: string[] = ['ca', 'da', 'es'];
+
+const EN_RULES: string[] = [
+  'chromevox',
+  'clearspeak',
+  'mathspeak',
+  'emacspeak',
+  'html'
+];

--- a/ts/common/options.ts
+++ b/ts/common/options.ts
@@ -165,4 +165,14 @@ export class Options {
     }
   }
 
+  json(): {[key: string]: boolean | string} {
+    const features: { [key: string]: string | boolean } = {};
+    const engineFeatures = [].concat(
+      Options.STRING_FEATURES,
+      Options.BINARY_FEATURES
+    );
+    engineFeatures.forEach(x => features[x] = (this as any)[x]);
+    return features;
+  }
+
 }

--- a/ts/common/options.ts
+++ b/ts/common/options.ts
@@ -23,7 +23,7 @@ import * as Dcstr from '../rule_engine/dynamic_cstr.js';
 
 export class Options {
 
-    /**
+  /**
    * Binary feature vector.
    */
   public static BINARY_FEATURES: string[] = [
@@ -36,7 +36,8 @@ export class Options {
     'aria',
     'pprint',
     'cayleyshort',
-    'linebreaks'
+    'linebreaks',
+    'tree'
   ];
 
   /**
@@ -48,7 +49,6 @@ export class Options {
     'domain',
     'speech',
     'walker',
-    'defaultLocale',
     'locale',
     'delay',
     'modality',
@@ -130,6 +130,7 @@ export class Options {
    */
   public structure = false;
   public aria = false;
+  public tree = false;
 
   /**
    * List of rule sets given as the constructor functions.

--- a/ts/common/options.ts
+++ b/ts/common/options.ts
@@ -133,11 +133,6 @@ export class Options {
   public tree = false;
 
   /**
-   * List of rule sets given as the constructor functions.
-   */
-  public ruleSets: string[] = [];
-
-  /**
    * Strict interpretations of rules and constraints.
    */
   public strict = false;

--- a/ts/common/options.ts
+++ b/ts/common/options.ts
@@ -1,0 +1,159 @@
+//
+// Copyright 2025-25 Volker Sorge
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Options object for controlling engine behaviour.
+ * @author volker.sorge@gmail.com (Volker Sorge)
+ */
+
+import * as EngineConst from './engine_const.js';
+import * as Dcstr from '../rule_engine/dynamic_cstr.js';
+
+export class Options {
+
+    /**
+   * Binary feature vector.
+   */
+  public static BINARY_FEATURES: string[] = [
+    'automark',
+    'mark',
+    'character',
+    'cleanpause',
+    'strict',
+    'structure',
+    'aria',
+    'pprint',
+    'cayleyshort',
+    'linebreaks'
+  ];
+
+  /**
+   * String feature vector.
+   */
+  public static STRING_FEATURES: string[] = [
+    'markup',
+    'style',
+    'domain',
+    'speech',
+    'walker',
+    'defaultLocale',
+    'locale',
+    'delay',
+    'modality',
+    'rate',
+    'rules',
+    'subiso',
+    'prune'
+  ];
+
+  /**
+   * Delay flag, to avoid auto setup of engine.
+   */
+  public delay = false;
+
+  /**
+   * Current domain.
+   */
+  public domain = 'mathspeak';
+
+  /**
+   * Current style.
+   */
+  public style = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.STYLE];
+
+  /**
+   * Current locale.
+   */
+  public locale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
+
+  /**
+   * Current subiso for the locale.
+   */
+  public subiso = '';
+
+  /**
+   * Current modality.
+   */
+  public modality = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.MODALITY];
+
+  /**
+   * The level to which speech attributes are added to enriched elements
+   * (none, shallow, deep).
+   */
+  public speech: EngineConst.Speech = EngineConst.Speech.NONE;
+
+  /**
+   * Caching during speech generation.
+   */
+  public markup: EngineConst.Markup = EngineConst.Markup.NONE;
+
+  // Markup options
+  public mark = true;
+  /**
+   * Automatic marking of elements for spans.
+   */
+  public automark = false;
+  public character = true;
+  public cleanpause = true;
+
+  /**
+   * Nemeth layout options
+   */
+  public cayleyshort = true;
+  public linebreaks = false;
+
+  /**
+   * Percentage of default rate used by external TTS. This can be used to scale
+   * pauses.
+   */
+  public rate = '100';
+
+  /**
+   * Current walker mode.
+   */
+  public walker = 'Table';
+
+  /**
+   * Indicates if skeleton structure attributes are added to enriched elements
+   */
+  public structure = false;
+  public aria = false;
+
+  /**
+   * List of rule sets given as the constructor functions.
+   */
+  public ruleSets: string[] = [];
+
+  /**
+   * Strict interpretations of rules and constraints.
+   */
+  public strict = false;
+
+  /**
+   * Pretty Print mode.
+   */
+  public pprint = false;
+
+  /**
+   * Rules file to load.
+   */
+  public rules = '';
+
+  /**
+   * EngineConstraints to prune given dot separated.
+   */
+  public prune = '';
+
+}

--- a/ts/common/processor_factory.ts
+++ b/ts/common/processor_factory.ts
@@ -250,7 +250,8 @@ set(
 set(
   new Processor<Element>('enriched', {
     processor: function (expr) {
-      return Enrich.semanticMathmlSync(expr);
+      return Enrich.semanticMathmlSync(
+        expr, Engine.getInstance().options);
     },
     postprocessor: function (enr, _expr) {
       const root = WalkerUtil.getSemanticRoot(enr);

--- a/ts/common/processor_factory.ts
+++ b/ts/common/processor_factory.ts
@@ -89,7 +89,7 @@ export function process<T>(name: string, expr: string): T {
  */
 function print<T>(name: string, data: T): string {
   const processor = get(name);
-  return Engine.getInstance().pprint
+  return Engine.getInstance().options.pprint
     ? processor.pprint(data)
     : processor.print(data);
 }
@@ -105,7 +105,7 @@ export function output(name: string, expr: string): string {
   const processor = get(name);
   try {
     const data = processor.processor(expr);
-    return Engine.getInstance().pprint
+    return Engine.getInstance().options.pprint
       ? processor.pprint(data)
       : processor.print(data);
   } catch (_e) {
@@ -125,7 +125,7 @@ export function keypress(name: string, expr: KeyCode | string): string {
   const processor = get(name);
   const key = processor instanceof KeyProcessor ? processor.key(expr) : expr;
   const data = processor.processor(key as string);
-  return Engine.getInstance().pprint
+  return Engine.getInstance().options.pprint
     ? processor.pprint(data)
     : processor.print(data);
 }
@@ -138,7 +138,7 @@ set(
       return Semantic.xmlTree(mml) as Element;
     },
     postprocessor: function (xml, _expr) {
-      const setting = Engine.getInstance().speech;
+      const setting = Engine.getInstance().options.speech;
       if (setting === EngineConst.Speech.NONE) {
         return xml;
       }
@@ -194,7 +194,7 @@ set(
       return stree.toJson();
     },
     postprocessor: function (json: any, expr) {
-      const setting = Engine.getInstance().speech;
+      const setting = Engine.getInstance().options.speech;
       if (setting === EngineConst.Speech.NONE) {
         return json;
       }
@@ -255,7 +255,7 @@ set(
     postprocessor: function (enr, _expr) {
       const root = WalkerUtil.getSemanticRoot(enr);
       let generator;
-      switch (Engine.getInstance().speech) {
+      switch (Engine.getInstance().options.speech) {
         case EngineConst.Speech.NONE:
           break;
         case EngineConst.Speech.SHALLOW:
@@ -296,10 +296,10 @@ set(
       const generator = SpeechGeneratorFactory.generator('Node');
       Processor.LocalState.speechGenerator = generator;
       generator.setOptions({
-        modality: Engine.getInstance().modality,
-        locale: Engine.getInstance().locale,
-        domain: Engine.getInstance().domain,
-        style: Engine.getInstance().style
+        modality: Engine.getInstance().options.modality,
+        locale: Engine.getInstance().options.locale,
+        domain: Engine.getInstance().options.domain,
+        style: Engine.getInstance().options.style
       });
       Processor.LocalState.highlighter = HighlighterFactory.highlighter(
         { color: 'black' },
@@ -309,7 +309,7 @@ set(
       const node = process('enriched', expr) as Element;
       const eml = print('enriched', node);
       Processor.LocalState.walker = WalkerFactory.walker(
-        Engine.getInstance().walker,
+        Engine.getInstance().options.walker,
         node,
         generator,
         Processor.LocalState.highlighter,
@@ -380,8 +380,8 @@ set(
   new Processor('latex', {
     processor: function (ltx: string) {
       if (
-        Engine.getInstance().modality !== 'braille' ||
-        Engine.getInstance().locale !== 'euro'
+        Engine.getInstance().options.modality !== 'braille' ||
+        Engine.getInstance().options.locale !== 'euro'
       ) {
         console.info(
           'LaTeX input currently only works for Euro Braille output.' +

--- a/ts/common/processor_factory.ts
+++ b/ts/common/processor_factory.ts
@@ -135,7 +135,7 @@ set(
   new Processor<Element>('semantic', {
     processor: function (expr) {
       const mml = DomUtil.parseInput(expr);
-      return Semantic.xmlTree(mml) as Element;
+      return Semantic.xmlTree(mml, Engine.getInstance().options) as Element;
     },
     postprocessor: function (xml, _expr) {
       const setting = Engine.getInstance().options.speech;
@@ -173,7 +173,7 @@ set(
   new Processor('speech', {
     processor: function (expr) {
       const mml = DomUtil.parseInput(expr);
-      const xml = Semantic.xmlTree(mml);
+      const xml = Semantic.xmlTree(mml, Engine.getInstance().options);
       const descrs = SpeechGeneratorUtil.computeSpeech(xml, true);
       return AuralRendering.finalize(AuralRendering.markup(descrs));
     },
@@ -190,7 +190,7 @@ set(
   new Processor('json', {
     processor: function (expr) {
       const mml = DomUtil.parseInput(expr);
-      const stree = Semantic.getTree(mml);
+      const stree = Semantic.getTree(mml, Engine.getInstance().options);
       return stree.toJson();
     },
     postprocessor: function (json: any, expr) {
@@ -199,7 +199,7 @@ set(
         return json;
       }
       const mml = DomUtil.parseInput(expr);
-      const xml = Semantic.xmlTree(mml);
+      const xml = Semantic.xmlTree(mml, Engine.getInstance().options);
       const speech = SpeechGeneratorUtil.computeMarkup(xml);
       if (setting === EngineConst.Speech.SHALLOW) {
         json.stree.speech = AuralRendering.finalize(speech);
@@ -233,7 +233,7 @@ set(
   new Processor('description', {
     processor: function (expr) {
       const mml = DomUtil.parseInput(expr);
-      const xml = Semantic.xmlTree(mml);
+      const xml = Semantic.xmlTree(mml, Engine.getInstance().options);
       const descrs = SpeechGeneratorUtil.computeSpeech(xml, true);
       return descrs;
     },

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -75,7 +75,6 @@ export function engineSetup(): { [key: string]: boolean | string } {
   });
   features.json = SystemExternal.jsonPath;
   features.xpath = SystemExternal.WGXpath;
-  features.rules = engine.ruleSets.slice();
   return features;
 }
 

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -64,12 +64,13 @@ export async function setupEngine(feature: {
  *     values.
  */
 export function engineSetup(): { [key: string]: boolean | string } {
-  const engineFeatures = ['mode'].concat(
+  const engineFeatures = [].concat(
     Options.STRING_FEATURES,
     Options.BINARY_FEATURES
   );
   const engine = Engine.getInstance() as any;
   const features: { [key: string]: string | boolean } = {};
+  features['mode'] = engine.mode;
   engineFeatures.forEach(function (x) {
     features[x] = engine.options[x];
   });

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -21,8 +21,7 @@
 import { AuditoryDescription } from '../audio/auditory_description.js';
 
 import { Engine, EnginePromise, SREError } from './engine.js';
-import { Options } from './options.js';
-import { setup } from './engine_setup.js';
+import { setupEngine as setup, engineSetup as engine } from './engine_setup.js';
 import * as EngineConst from './engine_const.js';
 import { KeyCode } from './event_util.js';
 import * as FileUtil from './file_util.js';
@@ -64,19 +63,7 @@ export async function setupEngine(feature: {
  *     values.
  */
 export function engineSetup(): { [key: string]: boolean | string } {
-  const engineFeatures = [].concat(
-    Options.STRING_FEATURES,
-    Options.BINARY_FEATURES
-  );
-  const engine = Engine.getInstance() as any;
-  const features: { [key: string]: string | boolean } = {};
-  features['mode'] = engine.mode;
-  engineFeatures.forEach(function (x) {
-    features[x] = engine.options[x];
-  });
-  features.json = SystemExternal.jsonPath;
-  features.xpath = SystemExternal.WGXpath;
-  return features;
+  return engine();
 }
 
 /**

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -67,6 +67,13 @@ export function engineSetup(): { [key: string]: boolean | string } {
 }
 
 /**
+ * Reset the engine options setup.
+ */
+export function resetEngine() {
+  return Engine.getInstance().reset();
+}
+
+/**
  * @returns True if engine is ready, i.e., unicode file for the current
  *     locale has been loaded.
  */

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -21,6 +21,7 @@
 import { AuditoryDescription } from '../audio/auditory_description.js';
 
 import { Engine, EnginePromise, SREError } from './engine.js';
+import { Options } from './options.js';
 import { setup } from './engine_setup.js';
 import * as EngineConst from './engine_const.js';
 import { KeyCode } from './event_util.js';
@@ -64,13 +65,13 @@ export async function setupEngine(feature: {
  */
 export function engineSetup(): { [key: string]: boolean | string } {
   const engineFeatures = ['mode'].concat(
-    Engine.STRING_FEATURES,
-    Engine.BINARY_FEATURES
+    Options.STRING_FEATURES,
+    Options.BINARY_FEATURES
   );
   const engine = Engine.getInstance() as any;
   const features: { [key: string]: string | boolean } = {};
   engineFeatures.forEach(function (x) {
-    features[x] = engine[x];
+    features[x] = engine.options[x];
   });
   features.json = SystemExternal.jsonPath;
   features.xpath = SystemExternal.WGXpath;
@@ -500,7 +501,7 @@ async function assembleWorkerStructure(
   options: OptionsList
 ): Promise<WorkerStructure> {
   await setupEngine(options);
-  Engine.getInstance().automark = true;
+  Engine.getInstance().options.automark = true;
   const json: WorkerStructure = {};
   json.options = options;
   json.mactions = SpeechGeneratorUtil.connectMactionSelections(mml, sxml);

--- a/ts/enrich_mathml/enrich.ts
+++ b/ts/enrich_mathml/enrich.ts
@@ -47,11 +47,11 @@ export function semanticMathmlNode(mml: Element): Element {
 export function semanticMathmlSync(expr: string): Element {
   const mml = DomUtil.parseInput(expr);
   try {
-    semanticMathmlNode(mml);
+    return semanticMathmlNode(mml);
   } catch (err) {
     console.error(err);
+    return mml;
   }
-  return semanticMathmlNode(mml);
 }
 
 /**

--- a/ts/enrich_mathml/enrich.ts
+++ b/ts/enrich_mathml/enrich.ts
@@ -18,7 +18,7 @@
  * @author volker.sorge@gmail.com (Volker Sorge)
  */
 
-import { Debugger } from '../common/debugger.js';
+// import { Debugger } from '../common/debugger.js';
 import * as DomUtil from '../common/dom_util.js';
 import { EnginePromise } from '../common/engine.js';
 import { Options } from '../common/options.js';
@@ -35,7 +35,7 @@ import './enrich_case_factory.js';
  */
 export function semanticMathmlNode(mml: Element, options: Options): Element {
   const clone = DomUtil.cloneNode(mml);
-  const tree = Semantic.getTree(clone);
+  const tree = Semantic.getTree(clone, options);
   return EnrichMathml.enrich(clone, tree, options);
 }
 
@@ -68,18 +68,18 @@ export function semanticMathml(expr: string, options: Options, callback: (p1: El
   });
 }
 
-/**
- * Tests for an expression with debugger output.
- *
- * @param expr MathML expression.
- * @returns The enriched MathML expression.
- */
-export function testTranslation(expr: string): Element {
-  Debugger.getInstance().init();
-  const mml = semanticMathmlSync(prepareMmlString(expr), options);
-  Debugger.getInstance().exit();
-  return mml;
-}
+// /**
+//  * Tests for an expression with debugger output.
+//  *
+//  * @param expr MathML expression.
+//  * @returns The enriched MathML expression.
+//  */
+// export function testTranslation(expr: string): Element {
+//   Debugger.getInstance().init();
+//   const mml = semanticMathmlSync(prepareMmlString(expr), options);
+//   Debugger.getInstance().exit();
+//   return mml;
+// }
 
 /**
  * Adds Math tags to a MathML string, if necessary.

--- a/ts/enrich_mathml/enrich.ts
+++ b/ts/enrich_mathml/enrich.ts
@@ -21,6 +21,7 @@
 import { Debugger } from '../common/debugger.js';
 import * as DomUtil from '../common/dom_util.js';
 import { EnginePromise } from '../common/engine.js';
+import { Options } from '../common/options.js';
 import * as Semantic from '../semantic_tree/semantic.js';
 
 import * as EnrichMathml from './enrich_mathml.js';
@@ -32,10 +33,10 @@ import './enrich_case_factory.js';
  * @param mml The original MathML node.
  * @returns Semantically enriched MathML node.
  */
-export function semanticMathmlNode(mml: Element): Element {
+export function semanticMathmlNode(mml: Element, options: Options): Element {
   const clone = DomUtil.cloneNode(mml);
   const tree = Semantic.getTree(clone);
-  return EnrichMathml.enrich(clone, tree);
+  return EnrichMathml.enrich(clone, tree, options);
 }
 
 /**
@@ -44,10 +45,10 @@ export function semanticMathmlNode(mml: Element): Element {
  * @param expr The MathML expression as a string without math tags.
  * @returns The modified MathML element.
  */
-export function semanticMathmlSync(expr: string): Element {
+export function semanticMathmlSync(expr: string, options: Options): Element {
   const mml = DomUtil.parseInput(expr);
   try {
-    return semanticMathmlNode(mml);
+    return semanticMathmlNode(mml, options);
   } catch (err) {
     console.error(err);
     return mml;
@@ -60,10 +61,10 @@ export function semanticMathmlSync(expr: string): Element {
  * @param expr The MathML expression as a string without math tags.
  * @param callback Function to apply on the result.
  */
-export function semanticMathml(expr: string, callback: (p1: Element) => any) {
+export function semanticMathml(expr: string, options: Options, callback: (p1: Element) => any) {
   EnginePromise.getall().then(() => {
     const mml = DomUtil.parseInput(expr);
-    callback(semanticMathmlNode(mml));
+    callback(semanticMathmlNode(mml, options));
   });
 }
 
@@ -75,7 +76,7 @@ export function semanticMathml(expr: string, callback: (p1: Element) => any) {
  */
 export function testTranslation(expr: string): Element {
   Debugger.getInstance().init();
-  const mml = semanticMathmlSync(prepareMmlString(expr));
+  const mml = semanticMathmlSync(prepareMmlString(expr), options);
   Debugger.getInstance().exit();
   return mml;
 }

--- a/ts/enrich_mathml/enrich_mathml.ts
+++ b/ts/enrich_mathml/enrich_mathml.ts
@@ -23,7 +23,7 @@
 
 // import { Debugger } from '../common/debugger.js';
 import * as DomUtil from '../common/dom_util.js';
-import { Engine } from '../common/engine.js';
+import { Options } from '../common/options.js';
 import { NamedSymbol } from '../semantic_tree/semantic_attr.js';
 import {
   SemanticRole,
@@ -64,16 +64,16 @@ const IDS = new Map();
  * @param semantic The semantic tree.
  * @returns The modified MathML element.
  */
-export function enrich(mml: Element, semantic: SemanticTree): Element {
+export function enrich(mml: Element, semantic: SemanticTree, options: Options): Element {
   // The first line is only to preserve output. This should eventually be
   // deleted.
   // const oldMml = DomUtil.cloneNode(mml);
   IDS.clear();
   walkTree(semantic.root);
-  if (Engine.getInstance().options.structure) {
+  if (options.structure) {
     mml.setAttribute(
       EnrichAttr.Attribute.STRUCTURE,
-      SemanticSkeleton.fromStructure(mml, semantic, Engine.getInstance().options).toString()
+      SemanticSkeleton.fromStructure(mml, semantic, options).toString()
     );
   }
   // Debugger.getInstance().generateOutput(() => [

--- a/ts/enrich_mathml/enrich_mathml.ts
+++ b/ts/enrich_mathml/enrich_mathml.ts
@@ -70,7 +70,7 @@ export function enrich(mml: Element, semantic: SemanticTree): Element {
   // const oldMml = DomUtil.cloneNode(mml);
   IDS.clear();
   walkTree(semantic.root);
-  if (Engine.getInstance().structure) {
+  if (Engine.getInstance().options.structure) {
     mml.setAttribute(
       EnrichAttr.Attribute.STRUCTURE,
       SemanticSkeleton.fromStructure(mml, semantic).toString()

--- a/ts/enrich_mathml/enrich_mathml.ts
+++ b/ts/enrich_mathml/enrich_mathml.ts
@@ -73,7 +73,7 @@ export function enrich(mml: Element, semantic: SemanticTree): Element {
   if (Engine.getInstance().options.structure) {
     mml.setAttribute(
       EnrichAttr.Attribute.STRUCTURE,
-      SemanticSkeleton.fromStructure(mml, semantic).toString()
+      SemanticSkeleton.fromStructure(mml, semantic, Engine.getInstance().options).toString()
     );
   }
   // Debugger.getInstance().generateOutput(() => [

--- a/ts/l10n/l10n.ts
+++ b/ts/l10n/l10n.ts
@@ -83,11 +83,11 @@ export function setLocale() {
  * @param msg The current locale message structure.
  */
 function setSubiso(msg: Locale) {
-  const subiso = Engine.getInstance().subiso;
+  const subiso = Engine.getInstance().options.subiso;
   if (msg.SUBISO.all.indexOf(subiso) === -1) {
-    Engine.getInstance().subiso = msg.SUBISO.default;
+    Engine.getInstance().options.subiso = msg.SUBISO.default;
   }
-  msg.SUBISO.current = Engine.getInstance().subiso;
+  msg.SUBISO.current = Engine.getInstance().options.subiso;
 }
 
 /**
@@ -98,10 +98,10 @@ function setSubiso(msg: Locale) {
  */
 function getLocale(): Locale {
   const locale = Variables.ensureLocale(
-    Engine.getInstance().locale,
+    Engine.getInstance().options.locale,
     Engine.getInstance().defaultLocale
   );
-  Engine.getInstance().locale = locale;
+  Engine.getInstance().options.locale = locale;
   return locales[locale]();
 }
 

--- a/ts/l10n/numbers/numbers_fr.ts
+++ b/ts/l10n/numbers/numbers_fr.ts
@@ -74,9 +74,9 @@ function numberToWords(num: number): string {
   if (num >= Math.pow(10, 36)) {
     return num.toString();
   }
-  if (NUMBERS.special['tens-' + Engine.getInstance().subiso]) {
+  if (NUMBERS.special['tens-' + Engine.getInstance().options.subiso]) {
     NUMBERS.tens = NUMBERS.special[
-      'tens-' + Engine.getInstance().subiso
+      'tens-' + Engine.getInstance().options.subiso
     ] as string[];
   }
   let pos = 0;

--- a/ts/l10n/numbers/numbers_nn.ts
+++ b/ts/l10n/numbers/numbers_nn.ts
@@ -256,7 +256,7 @@ function numberToWordsGe(num: number, ordinal = false): string {
  */
 function numberToWords(num: number, ordinal = false): string {
   const word =
-    Engine.getInstance().subiso === 'alt'
+    Engine.getInstance().options.subiso === 'alt'
       ? numberToWordsGe(num, ordinal)
       : numberToWordsRo(num, ordinal);
   return word;

--- a/ts/rule_engine/grammar.ts
+++ b/ts/rule_engine/grammar.ts
@@ -153,9 +153,9 @@ export class Grammar {
     text = Grammar.prepareUnit(text);
     const engine = Engine.getInstance();
     const plural = Grammar.getInstance().getParameter('plural');
-    const strict = engine.strict;
-    const baseCstr = `${engine.locale}.${engine.modality}.default`;
-    engine.strict = true;
+    const strict = engine.options.strict;
+    const baseCstr = `${engine.options.locale}.${engine.options.modality}.default`;
+    engine.options.strict = true;
     let cstr: DynamicCstr;
     let result: string;
     if (plural) {
@@ -163,12 +163,12 @@ export class Grammar {
       result = engine.evaluator(text, cstr);
     }
     if (result) {
-      engine.strict = strict;
+      engine.options.strict = strict;
       return result;
     }
     cstr = engine.defaultParser.parse(baseCstr + '.default');
     result = engine.evaluator(text, cstr);
-    engine.strict = strict;
+    engine.options.strict = strict;
     if (!result) {
       return Grammar.cleanUnit(text);
     }
@@ -433,7 +433,7 @@ export function correctFont(text: string, correction: string): string {
  * @returns The cleaned up string.
  */
 function correctCaps(text: string): string {
-  let cap = LOCALE.ALPHABETS.capPrefix[Engine.getInstance().domain];
+  let cap = LOCALE.ALPHABETS.capPrefix[Engine.getInstance().options.domain];
   if (typeof cap === 'undefined') {
     cap = LOCALE.ALPHABETS.capPrefix['default'];
   }

--- a/ts/rule_engine/math_simple_store.ts
+++ b/ts/rule_engine/math_simple_store.ts
@@ -97,7 +97,7 @@ export class MathSimpleStore {
     dynamic: DynamicCstr,
     rule: SimpleRule
   ): boolean {
-    if (Engine.getInstance().strict) {
+    if (Engine.getInstance().options.strict) {
       return rule.cstr.equal(dynamic);
     }
     return Engine.getInstance().comparator.match(rule.cstr);

--- a/ts/rule_engine/speech_rule_engine.ts
+++ b/ts/rule_engine/speech_rule_engine.ts
@@ -37,6 +37,7 @@ import { Span } from '../audio/span.js';
 import { Debugger } from '../common/debugger.js';
 import * as DomUtil from '../common/dom_util.js';
 import { Engine } from '../common/engine.js';
+import { Options } from '../common/options.js';
 import * as EngineConst from '../common/engine_const.js';
 import { evalXPath, updateEvaluator } from '../common/xpath_util.js';
 import { ClearspeakPreferences } from '../speech_rules/clearspeak_preferences.js';
@@ -178,17 +179,19 @@ export class SpeechRuleEngine {
     settings: { [feature: string]: string | boolean },
     callback: () => AuditoryDescription[]
   ): AuditoryDescription[] {
-    const engine = Engine.getInstance() as any;
-    const save: { [feature: string]: string | boolean } = {};
-    for (const [key, val] of Object.entries(settings)) {
-      save[key] = engine[key];
-      engine[key] = val;
+    const engine = Engine.getInstance();
+    const save = engine.options as any;
+    const newOpt = new Options() as any;
+    for (const key of Options.BINARY_FEATURES) {
+      newOpt[key] = settings[key] ?? save[key];
     }
+    for (const key of Options.STRING_FEATURES) {
+      newOpt[key] = settings[key] ?? save[key];
+    }
+    engine.options = newOpt;
     engine.setDynamicCstr();
     const result = callback();
-    for (const [key, val] of Object.entries(save)) {
-      engine[key] = val;
-    }
+    engine.options = save;
     engine.setDynamicCstr();
     return result;
   }
@@ -317,7 +320,7 @@ export class SpeechRuleEngine {
    */
   private evaluateTree_(node: Element): AuditoryDescription[] {
     const result = this.evaluateTreeInternal_(node);
-    this.speechStructure.addNode(node, result, Engine.getInstance().modality);
+    this.speechStructure.addNode(node, result, Engine.getInstance().options.modality);
     return result;
   }
 
@@ -336,10 +339,10 @@ export class SpeechRuleEngine {
     Grammar.getInstance().setAttribute(node);
     const rule = this.lookupRule(node, engine.dynamicCstr);
     if (!rule) {
-      if (engine.strict) {
+      if (engine.options.strict) {
         return [];
       }
-      result = this.getEvaluator(engine.locale, engine.modality)(node);
+      result = this.getEvaluator(engine.options.locale, engine.options.modality)(node);
       if (node.attributes) {
         this.addPersonality_(result, {}, false, node);
       }
@@ -681,7 +684,7 @@ export class SpeechRuleEngine {
   //       Try to make this dependent on the order of the dynamicCstr.
   private updateConstraint_() {
     const dynamic = Engine.getInstance().dynamicCstr;
-    const strict = Engine.getInstance().strict;
+    const strict = Engine.getInstance().options.strict;
     const trie = this.trie;
     const props: { [key: string]: string[] } = {};
     let locale = dynamic.getValue(Axis.LOCALE);

--- a/ts/rule_engine/speech_structure.ts
+++ b/ts/rule_engine/speech_structure.ts
@@ -136,15 +136,15 @@ export class SpeechStructure {
    * @param func The function to use for completion.
    */
   public completeModality(modality: string, func: any) {
-    const oldModality = Engine.getInstance().modality;
-    Engine.getInstance().modality = modality;
+    const oldModality = Engine.getInstance().options.modality;
+    Engine.getInstance().options.modality = modality;
     for (const [id, descrs] of this.getNodeMap()) {
       const speechMap = this.getSpeechMap(id);
       if (!speechMap.has(modality)) {
         func(descrs);
       }
     }
-    Engine.getInstance().modality = oldModality;
+    Engine.getInstance().options.modality = oldModality;
   }
 
   /**
@@ -156,16 +156,16 @@ export class SpeechStructure {
     const result: {
       [id: string]: { [modality: string]: string };
     } = {};
-    const oldMarkup = Engine.getInstance().markup;
+    const oldMarkup = Engine.getInstance().options.markup;
     for (const [id, map] of this.speechMaps) {
       const modality: { [modality: string]: string } = {};
       for (const ml of mls) {
-        Engine.getInstance().markup = ml as Markup;
+        Engine.getInstance().options.markup = ml as Markup;
         map.forEach((x, y) => (modality[`${y}-${ml}`] = markup(x)));
         result[id] = modality;
       }
     }
-    Engine.getInstance().markup = oldMarkup;
+    Engine.getInstance().options.markup = oldMarkup;
     return result;
   }
 }

--- a/ts/semantic_tree/semantic.ts
+++ b/ts/semantic_tree/semantic.ts
@@ -19,6 +19,7 @@
  */
 
 import * as DomUtil from '../common/dom_util.js';
+import { Options } from '../common/options.js';
 import {
   SemanticFont,
   SemanticRole,
@@ -49,8 +50,8 @@ export { Attr };
  * @param mml The MathML node.
  * @returns Semantic tree for input node as XML node.
  */
-export function xmlTree(mml: Element): Element {
-  return getTree(mml).xml();
+export function xmlTree(mml: Element, options: Options): Element {
+  return getTree(mml, options).xml();
 }
 
 /**
@@ -59,8 +60,8 @@ export function xmlTree(mml: Element): Element {
  * @param mml The MathML node.
  * @returns Semantic tree for input node.
  */
-export function getTree(mml: Element): SemanticTree {
-  return new SemanticTree(mml);
+export function getTree(mml: Element, options: Options): SemanticTree {
+  return new SemanticTree(mml, options);
 }
 
 /**
@@ -69,7 +70,7 @@ export function getTree(mml: Element): SemanticTree {
  * @param expr The string representing the MathML expression.
  * @returns Semantic tree for input string as XML node.
  */
-export function getTreeFromString(expr: string): SemanticTree {
+export function getTreeFromString(expr: string, options: Options): SemanticTree {
   const mml = DomUtil.parseInput(expr);
-  return getTree(mml);
+  return getTree(mml, options);
 }

--- a/ts/semantic_tree/semantic_heuristic_factory.ts
+++ b/ts/semantic_tree/semantic_heuristic_factory.ts
@@ -24,9 +24,12 @@ import {
   SemanticHeuristicTypes
 } from './semantic_heuristic.js';
 import { SemanticNodeFactory } from './semantic_node_factory.js';
+import { Options } from '../common/options.js';
 
 export const SemanticHeuristics = {
   factory: null as SemanticNodeFactory,
+
+  options: new Options(),
 
   /**
    * Updates the semantic node factory.

--- a/ts/semantic_tree/semantic_heuristics.ts
+++ b/ts/semantic_tree/semantic_heuristics.ts
@@ -35,7 +35,7 @@ import * as SemanticPred from './semantic_pred.js';
 import { SemanticProcessor } from './semantic_processor.js';
 import * as SemanticUtil from './semantic_util.js';
 import { SemanticSkeleton } from './semantic_skeleton.js';
-import { MMLTAGS } from '../semantic_tree/semantic_util.js';
+import { MMLTAGS } from './semantic_util.js';
 
 import * as DomUtil from '../common/dom_util.js';
 

--- a/ts/semantic_tree/semantic_heuristics.ts
+++ b/ts/semantic_tree/semantic_heuristics.ts
@@ -805,8 +805,8 @@ function combinedNodes(nodes: SemanticNode[], role: SemanticRole) {
 }
 
 /**
- * Rewrites a simple function to a prefix function if it consists of multiple
- * letters. (Currently restricted to Braille!)
+ * Rewrites simple operations with indexing style limits into large operators of
+ * role sum.
  */
 SemanticHeuristics.add(
   new SemanticMultiHeuristic(

--- a/ts/semantic_tree/semantic_heuristics.ts
+++ b/ts/semantic_tree/semantic_heuristics.ts
@@ -21,7 +21,6 @@
  */
 
 import { Debugger } from '../common/debugger.js';
-import { Engine } from '../common/engine.js';
 import { SemanticMap, NamedSymbol } from './semantic_attr.js';
 import { SemanticHeuristics } from './semantic_heuristic_factory.js';
 import {
@@ -90,7 +89,7 @@ SemanticHeuristics.add(
       }
       return node;
     },
-    (_node: SemanticNode) => Engine.getInstance().options.domain === 'clearspeak'
+    (_node: SemanticNode) => SemanticHeuristics.options.domain === 'clearspeak'
   )
 );
 
@@ -111,7 +110,7 @@ SemanticHeuristics.add(
       }
       return node;
     },
-    (_node: SemanticNode) => Engine.getInstance().options.domain === 'clearspeak'
+    (_node: SemanticNode) => SemanticHeuristics.options.domain === 'clearspeak'
   )
 );
 
@@ -131,7 +130,7 @@ SemanticHeuristics.add(
       }
       return node;
     },
-    (_node: SemanticNode) => Engine.getInstance().options.domain === 'clearspeak'
+    (_node: SemanticNode) => SemanticHeuristics.options.domain === 'clearspeak'
   )
 );
 
@@ -210,7 +209,7 @@ SemanticHeuristics.add(
       return node;
     },
     (node: SemanticNode) =>
-      Engine.getInstance().options.modality === 'braille' &&
+      SemanticHeuristics.options.modality === 'braille' &&
       node.type === SemanticType.IDENTIFIER
   )
 );

--- a/ts/semantic_tree/semantic_heuristics.ts
+++ b/ts/semantic_tree/semantic_heuristics.ts
@@ -90,7 +90,7 @@ SemanticHeuristics.add(
       }
       return node;
     },
-    (_node: SemanticNode) => Engine.getInstance().domain === 'clearspeak'
+    (_node: SemanticNode) => Engine.getInstance().options.domain === 'clearspeak'
   )
 );
 
@@ -111,7 +111,7 @@ SemanticHeuristics.add(
       }
       return node;
     },
-    (_node: SemanticNode) => Engine.getInstance().domain === 'clearspeak'
+    (_node: SemanticNode) => Engine.getInstance().options.domain === 'clearspeak'
   )
 );
 
@@ -131,7 +131,7 @@ SemanticHeuristics.add(
       }
       return node;
     },
-    (_node: SemanticNode) => Engine.getInstance().domain === 'clearspeak'
+    (_node: SemanticNode) => Engine.getInstance().options.domain === 'clearspeak'
   )
 );
 
@@ -210,7 +210,7 @@ SemanticHeuristics.add(
       return node;
     },
     (node: SemanticNode) =>
-      Engine.getInstance().modality === 'braille' &&
+      Engine.getInstance().options.modality === 'braille' &&
       node.type === SemanticType.IDENTIFIER
   )
 );

--- a/ts/semantic_tree/semantic_mathml.ts
+++ b/ts/semantic_tree/semantic_mathml.ts
@@ -30,7 +30,7 @@ import { SemanticAbstractParser } from './semantic_parser.js';
 import * as SemanticPred from './semantic_pred.js';
 import { SemanticProcessor } from './semantic_processor.js';
 import * as SemanticUtil from './semantic_util.js';
-import { MMLTAGS } from '../semantic_tree/semantic_util.js';
+import { MMLTAGS } from './semantic_util.js';
 import { SemanticHeuristics } from './semantic_heuristic_factory.js';
 
 export class SemanticMathml extends SemanticAbstractParser<Element> {

--- a/ts/semantic_tree/semantic_mathml.ts
+++ b/ts/semantic_tree/semantic_mathml.ts
@@ -19,6 +19,7 @@
  */
 
 import * as DomUtil from '../common/dom_util.js';
+import { Options } from '../common/options.js';
 import {
   SemanticFont,
   SemanticRole,
@@ -63,8 +64,10 @@ export class SemanticMathml extends SemanticAbstractParser<Element> {
   /**
    * The semantic parser for MathML elements.
    */
-  constructor() {
+  constructor(public options: Options) {
     super('MathML');
+    // TODO: process options, in particular for heuristics
+    SemanticHeuristics.options = options;
     this.parseMap_ = new Map([
       [MMLTAGS.SEMANTICS, this.semantics_.bind(this)],
       [MMLTAGS.MATH, this.rows_.bind(this)],

--- a/ts/semantic_tree/semantic_processor.ts
+++ b/ts/semantic_tree/semantic_processor.ts
@@ -35,7 +35,7 @@ import { SemanticNode } from './semantic_node.js';
 import { SemanticNodeFactory } from './semantic_node_factory.js';
 import * as SemanticPred from './semantic_pred.js';
 import * as SemanticUtil from './semantic_util.js';
-import { MMLTAGS } from '../semantic_tree/semantic_util.js';
+import { MMLTAGS } from './semantic_util.js';
 
 interface BoundsType {
   type: SemanticType;

--- a/ts/semantic_tree/semantic_skeleton.ts
+++ b/ts/semantic_tree/semantic_skeleton.ts
@@ -346,7 +346,7 @@ export class SemanticSkeleton {
     setsize: number,
     role: string = !Options.tree ? 'treeitem' : level ? 'treeitem' : 'tree'
   ) {
-    if (!Engine.getInstance().aria || !node) {
+    if (!Engine.getInstance().options.aria || !node) {
       return;
     }
     // Aria elements

--- a/ts/semantic_tree/semantic_skeleton.ts
+++ b/ts/semantic_tree/semantic_skeleton.ts
@@ -20,7 +20,7 @@
  */
 
 import * as BaseUtil from '../common/base_util.js';
-import { Engine } from '../common/engine.js';
+import { Options } from '../common/options.js';
 
 import * as XpathUtil from '../common/xpath_util.js';
 import { Attribute as EnrichAttribute } from '../enrich_mathml/enrich_attr.js';
@@ -29,10 +29,6 @@ import { SemanticNode } from './semantic_node.js';
 import { SemanticTree } from './semantic_tree.js';
 
 export type Sexp = number | Sexp[];
-
-const Options = {
-  tree: false
-};
 
 /**
  * @param skeleton The skeleton array.
@@ -140,13 +136,16 @@ export class SemanticSkeleton {
    *
    * @param mml A mml node to add a structure to.
    * @param tree A semantic tree.
+   * @param options The system options.
    * @returns The skeletal structure.
    */
   public static fromStructure(
     mml: Element,
-    tree: SemanticTree
+    tree: SemanticTree,
+    options: Options
   ): SemanticSkeleton {
-    return new SemanticSkeleton(SemanticSkeleton.tree_(mml, tree.root));
+    return new SemanticSkeleton(
+      SemanticSkeleton.tree_(mml, tree.root, options));
   }
 
   /**
@@ -272,6 +271,7 @@ export class SemanticSkeleton {
    *
    * @param mml A mml node to add a structure to.
    * @param node A semantic node.
+   * @param options The system options.
    * @param level The level in the tree, used for aria-level.
    * @param posinset The position in the child set, used for aria-posinset.
    * @param setsize The size of the child set, used for aria-setsize.
@@ -280,6 +280,7 @@ export class SemanticSkeleton {
   private static tree_(
     mml: Element,
     node: SemanticNode,
+    options: Options,
     level = 0,
     posinset = 1,
     setsize = 1
@@ -295,7 +296,7 @@ export class SemanticSkeleton {
       mml
     )[0] as Element;
     if (!node.childNodes.length) {
-      SemanticSkeleton.addAria(mmlChild, level, posinset, setsize);
+      SemanticSkeleton.addAria(mmlChild, level, posinset, setsize, options);
       return node.id;
     }
     const children = SemanticSkeleton.combineContentChildren<SemanticNode>(
@@ -317,7 +318,7 @@ export class SemanticSkeleton {
       i++
     ) {
       skeleton.push(
-        SemanticSkeleton.tree_(mml, child, level + 1, i + 1, l) as any
+        SemanticSkeleton.tree_(mml, child, options, level + 1, i + 1, l) as any
       );
     }
     SemanticSkeleton.addAria(
@@ -325,7 +326,7 @@ export class SemanticSkeleton {
       level,
       posinset,
       setsize,
-      !Options.tree ? 'treeitem' : level ? 'group' : 'tree'
+      options
     );
     return skeleton;
   }
@@ -337,16 +338,17 @@ export class SemanticSkeleton {
    * @param level The level in the tree, used for aria-level.
    * @param posinset The position in the child set, used for aria-posinset.
    * @param setsize The size of the child set, used for aria-setsize.
-   * @param role The aria-role to add.
+   * @param options The system options.
    */
   private static addAria(
     node: Element,
     level: number,
     posinset: number,
     setsize: number,
-    role: string = !Options.tree ? 'treeitem' : level ? 'treeitem' : 'tree'
+    options: Options
   ) {
-    if (!Engine.getInstance().options.aria || !node) {
+    const role = !options.tree ? 'treeitem' : level ? 'treeitem' : 'tree'
+    if (!options.aria || !node) {
       return;
     }
     // Aria elements

--- a/ts/semantic_tree/semantic_tree.ts
+++ b/ts/semantic_tree/semantic_tree.ts
@@ -25,6 +25,7 @@
  */
 
 import * as DomUtil from '../common/dom_util.js';
+import { Options } from '../common/options.js';
 
 import { annotate } from './semantic_annotations.js';
 import { SemanticVisitor } from './semantic_annotator.js';
@@ -40,7 +41,7 @@ export class SemanticTree {
   /**
    * The root of the tree.
    */
-  public parser: SemanticParser<Element> = new SemanticMathml();
+  public parser: SemanticParser<Element>;
 
   /**
    * The root of the tree.
@@ -59,7 +60,7 @@ export class SemanticTree {
    */
   public static empty(): SemanticTree {
     const empty = DomUtil.parseInput('<math/>');
-    const stree = new SemanticTree(empty);
+    const stree = new SemanticTree(empty, new Options());
     stree.mathml = empty;
     return stree;
   }
@@ -128,14 +129,15 @@ export class SemanticTree {
    *
    * @param mathml The original MathML node.
    */
-  constructor(public mathml: Element) {
+  constructor(public mathml: Element, public options: Options) {
+    this.parser = new SemanticMathml(options);
     this.root = this.parser.parse(mathml);
     this.collator = this.parser.getFactory().leafMap.collateMeaning();
 
     const newDefault = this.collator.newDefault();
     if (newDefault) {
       // Reparse!
-      this.parser = new SemanticMathml();
+      this.parser = new SemanticMathml(options);
       this.parser.getFactory().defaultMap = newDefault;
       this.root = this.parser.parse(mathml);
     }

--- a/ts/speech_generator/abstract_speech_generator.ts
+++ b/ts/speech_generator/abstract_speech_generator.ts
@@ -19,7 +19,7 @@
  * @author volker.sorge@gmail.com (Volker Sorge)
  */
 
-import { setup as EngineSetup } from '../common/engine_setup.js';
+import { setupEngine } from '../common/engine_setup.js';
 import * as EnrichAttr from '../enrich_mathml/enrich_attr.js';
 import { AxisMap } from '../rule_engine/dynamic_cstr.js';
 import { RebuildStree } from '../walker/rebuild_stree.js';
@@ -101,7 +101,7 @@ export abstract class AbstractSpeechGenerator implements SpeechGenerator {
     if (!this.rebuilt_) {
       this.rebuilt_ = new RebuildStree(xml);
     }
-    EngineSetup(this.options_);
+    setupEngine(this.options_);
     return SpeechGeneratorUtil.computeMarkup(this.getRebuilt().xml);
   }
 

--- a/ts/speech_generator/summary_speech_generator.ts
+++ b/ts/speech_generator/summary_speech_generator.ts
@@ -22,7 +22,7 @@
 
 import { AbstractSpeechGenerator } from './abstract_speech_generator.js';
 import * as SpeechGeneratorUtil from './speech_generator_util.js';
-import { setup as EngineSetup } from '../common/engine_setup.js';
+import { setupEngine } from '../common/engine_setup.js';
 import { Attribute } from '../enrich_mathml/enrich_attr.js';
 
 export class SummarySpeechGenerator extends AbstractSpeechGenerator {
@@ -31,7 +31,7 @@ export class SummarySpeechGenerator extends AbstractSpeechGenerator {
    */
   public getSpeech(node: Element, _xml: Element) {
     // SpeechGeneratorUtil.connectAllMactions(xml, this.getRebuilt().xml);
-    EngineSetup(this.getOptions());
+    setupEngine(this.getOptions());
     const id = node.getAttribute(Attribute.ID);
     const snode = this.getRebuilt().streeRoot.querySelectorAll(
       (x) => x.id.toString() === id

--- a/ts/speech_rules/alphabet_generator.ts
+++ b/ts/speech_rules/alphabet_generator.ts
@@ -76,8 +76,8 @@ export function generateBase() {
  * @param locale The current locale.
  */
 export function generate(locale: string) {
-  const oldLocale = Engine.getInstance().locale;
-  Engine.getInstance().locale = locale;
+  const oldLocale = Engine.getInstance().options.locale;
+  Engine.getInstance().options.locale = locale;
   L10n.setLocale();
   MathCompoundStore.changeLocale({ locale: locale } as UnicodeJson);
   makeDomains();
@@ -90,7 +90,7 @@ export function generate(locale: string) {
       alphabetRules(letters, alphabet, int.font, !!int.capital);
     }
   }
-  Engine.getInstance().locale = oldLocale;
+  Engine.getInstance().options.locale = oldLocale;
   L10n.setLocale();
 }
 

--- a/ts/speech_rules/clearspeak_util.ts
+++ b/ts/speech_rules/clearspeak_util.ts
@@ -291,7 +291,7 @@ function isSimpleFraction_(node: SemanticNode): boolean {
  * @returns True of the given preference is set.
  */
 function hasPreference(pref: string): boolean {
-  return Engine.getInstance().style === pref;
+  return Engine.getInstance().options.style === pref;
 }
 
 register(

--- a/ts/speech_rules/math_map.ts
+++ b/ts/speech_rules/math_map.ts
@@ -69,7 +69,7 @@ let _init = false;
  *     engine.
  * @returns Promise that resolves once locale is loaded.
  */
-export async function loadLocale(locale = Engine.getInstance().locale) {
+export async function loadLocale(locale = Engine.getInstance().options.locale) {
   if (!_init) {
     // Generate base alphabet information.
     AlphabetGenerator.generateBase();
@@ -96,7 +96,7 @@ export async function loadLocale(locale = Engine.getInstance().locale) {
  * @param locale The locale to be loaded. Defaults to current locale of the
  *     engine.
  */
-function _loadLocale(locale = Engine.getInstance().locale) {
+function _loadLocale(locale = Engine.getInstance().options.locale) {
   if (!EnginePromise.loaded[locale]) {
     EnginePromise.loaded[locale] = [false, false];
     MathCompoundStore.reset();
@@ -152,7 +152,7 @@ function retrieveFiles(locale: string) {
       (_err: string) => {
         EnginePromise.loaded[locale] = [true, false];
         console.error(`Unable to load locale: ${locale}`);
-        Engine.getInstance().locale = Engine.getInstance().defaultLocale;
+        Engine.getInstance().options.locale = Engine.getInstance().defaultLocale;
         res(locale);
       }
     );

--- a/ts/walker/abstract_walker.ts
+++ b/ts/walker/abstract_walker.ts
@@ -21,7 +21,7 @@
 import { AuditoryDescription } from '../audio/auditory_description.js';
 import * as AuralRendering from '../audio/aural_rendering.js';
 import * as DomUtil from '../common/dom_util.js';
-import { setup as EngineSetup } from '../common/engine_setup.js';
+import { setupEngine } from '../common/engine_setup.js';
 import { KeyCode } from '../common/event_util.js';
 import { Attribute } from '../enrich_mathml/enrich_attr.js';
 import { Highlighter } from '../highlighter/highlighter.js';
@@ -743,7 +743,7 @@ export abstract class AbstractWalker<T> implements Walker {
    * @override
    */
   public update(options: AxisMap) {
-    EngineSetup(options).then(() =>
+    setupEngine(options).then(() =>
       SpeechGeneratorFactory.generator('Tree').getSpeech(
         this.node,
         this.getXml()


### PR DESCRIPTION
* Separates string and boolean options from the `Engine` singleton into a separate class.
* Allows for independent parameterization of semantic and enrich module.
