### PR TITLE
fixes missing completion for Euro Braille

### DIFF
--- a/ts/speech_generator/speech_generator_util.ts
+++ b/ts/speech_generator/speech_generator_util.ts
@@ -458,6 +458,7 @@ export function computeSpeechStructure(sxml: Element) {
 export function computeBrailleStructure(sxml: Element) {
   computeSpeech(sxml, true);
   const structure = SpeechRuleEngine.getInstance().speechStructure;
+  structure.completeModality('braille', computeSpeech);
   return structure.json(['none']);
 }
 


### PR DESCRIPTION
Fixes missing completions for Euro Braille in speech structure that is passed to the worker.  Nodes in the subtree did not get completed when the LaTeX was given on the top node.
