### PR TITLE
fixes label issue

### DIFF
--- a/mathmaps/base/rules/prefix_base.json
+++ b/mathmaps/base/rules/prefix_base.json
@@ -370,14 +370,16 @@
       "Precondition",
       "cell-simple-short",
       "clearspeak.default",
-      "self::cell"
+      "self::cell",
+      "@role!=\"label\""
     ],
     [
       "Precondition",
       "cell-short",
       "clearspeak.default",
       "self::cell",
-      "contains(@grammar,\"depth\")"
+      "contains(@grammar,\"depth\")",
+      "@role!=\"label\""
     ],
     [
       "Precondition",

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -598,7 +598,7 @@ argument, that enforces overwrite when set to true.
 Tests can be generated or regenerated using the `fill_tests` module:
 
 ``` javascript
-(await import('./js/module_loader.js')).load('ft');
+const ft = await (await import('./js/module_loader.js')).loadPromise('ft');
 ```
 
 Each of the following commands takes an path to a file with expected values and

--- a/testsuite/expected/af/clearspeak/prefix_tables.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Lyn 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Geval 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "beperking 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Vergelyking 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Lyn 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Lyn 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Ry 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/af/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Stap 2, Kolom 2"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   },
   "compare": true

--- a/testsuite/expected/af/mathspeak/prefix_tables.json
+++ b/testsuite/expected/af/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2. Ry, 2. kolom"
+    },
+    "Table_Label_0": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_1": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_2": {
+      "expected": "Opskrif"
+    },
+    "Table_Label_3": {
+      "expected": "Opskrif"
     }
   }
 }

--- a/testsuite/expected/ca/mathspeak/prefix_tables.json
+++ b/testsuite/expected/ca/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2a fila, 2a columna"
+    },
+    "Table_Label_0": {
+      "expected": "1a columna"
+    },
+    "Table_Label_1": {
+      "expected": "1a columna"
+    },
+    "Table_Label_2": {
+      "expected": "1a columna"
+    },
+    "Table_Label_3": {
+      "expected": "1a columna"
     }
   }
 }

--- a/testsuite/expected/da/mathspeak/prefix_tables.json
+++ b/testsuite/expected/da/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2. Række, 2. Kolonne"
+    },
+    "Table_Label_0": {
+      "expected": "1. Kolonne"
+    },
+    "Table_Label_1": {
+      "expected": "1. Kolonne"
+    },
+    "Table_Label_2": {
+      "expected": "1. Kolonne"
+    },
+    "Table_Label_3": {
+      "expected": "1. Kolonne"
     }
   }
 }

--- a/testsuite/expected/de/clearspeak/prefix_tables.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Zeile 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Fall 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Bedingung 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Gleichung 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Zeile 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Zeile 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Zeile 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/de/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Schritt 2, Spalte 2"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   },
   "compare": true

--- a/testsuite/expected/de/mathspeak/prefix_tables.json
+++ b/testsuite/expected/de/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2. Zeile, 2. Spalte"
+    },
+    "Table_Label_0": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_1": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_2": {
+      "expected": "Bezeichner"
+    },
+    "Table_Label_3": {
+      "expected": "Bezeichner"
     }
   }
 }

--- a/testsuite/expected/en-ssml/mathspeak/prefix_tables.json
+++ b/testsuite/expected/en-ssml/mathspeak/prefix_tables.json
@@ -171,6 +171,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "<mark name=\"9\"/> 2nd Row <break time=\"200ms\"/> <mark name=\"8\"/> 2nd Column <break time=\"200ms\"/>"
+    },
+    "Table_Label_0": {
+      "expected": "<mark name=\"1\"/> Label <break time=\"200ms\"/>"
+    },
+    "Table_Label_1": {
+      "expected": "<mark name=\"1\"/> Label <break time=\"200ms\"/>"
+    },
+    "Table_Label_2": {
+      "expected": "<mark name=\"1\"/> Label <break time=\"200ms\"/>"
+    },
+    "Table_Label_3": {
+      "expected": "<mark name=\"8\"/> Label <break time=\"200ms\"/>"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Line 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Case 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Constraint 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Equation 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Line 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Line 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Row 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/en/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Step 2, Column 2"
+    },
+    "Table_Label_0": {
+      "expected": "Label"
+    },
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/en/mathspeak/prefix_tables.json
+++ b/testsuite/expected/en/mathspeak/prefix_tables.json
@@ -23,6 +23,12 @@
     "Binomials_4": {
       "expected": ""
     },
+    "Binomials_0_extra": {
+      "expected": "Choice Quantity"
+    },
+    "Binomials_1_extra": {
+      "expected": "Selection Quantity"
+    },
     "Vectors_0": {
       "expected": "1st Row"
     },
@@ -167,11 +173,17 @@
     "Table_Cell_Depth_5a": {
       "expected": "2nd Row, 2nd Column"
     },
-    "Binomials_0_extra": {
-      "expected": "Choice Quantity"
+    "Table_Label_0": {
+      "expected": "Label"
     },
-    "Binomials_1_extra": {
-      "expected": "Selection Quantity"
+    "Table_Label_1": {
+      "expected": "Label"
+    },
+    "Table_Label_2": {
+      "expected": "Label"
+    },
+    "Table_Label_3": {
+      "expected": "Label"
     }
   }
 }

--- a/testsuite/expected/es/mathspeak/prefix_tables.json
+++ b/testsuite/expected/es/mathspeak/prefix_tables.json
@@ -171,6 +171,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2a fila, 2a columna"
+    },
+    "Table_Label_0": {
+      "expected": "1a columna"
+    },
+    "Table_Label_1": {
+      "expected": "1a columna"
+    },
+    "Table_Label_2": {
+      "expected": "1a columna"
+    },
+    "Table_Label_3": {
+      "expected": "1a columna"
     }
   }
 }

--- a/testsuite/expected/fr/clearspeak/prefix_tables.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Ligne 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Cas 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Contrainte 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Équation 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Ligne 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Ligne 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Rangée 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/fr/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Étape 2, colonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   },
   "compare": true

--- a/testsuite/expected/fr/mathspeak/prefix_tables.json
+++ b/testsuite/expected/fr/mathspeak/prefix_tables.json
@@ -171,6 +171,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2e rangée, 2e colonne"
+    },
+    "Table_Label_0": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_1": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_2": {
+      "expected": "Étiquette"
+    },
+    "Table_Label_3": {
+      "expected": "Étiquette"
     }
   }
 }

--- a/testsuite/expected/hi/clearspeak/prefix_tables.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "रेखा 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "फलन उपशर्त 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "व्यवरोध 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "समीकरण 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "रेखा 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "रेखा 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "पंक्ति 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/hi/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "चरण 2, स्तंभ 2"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   },
   "compare": true

--- a/testsuite/expected/hi/mathspeak/prefix_tables.json
+++ b/testsuite/expected/hi/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "२री पंक्ति, २रा स्तंभ"
+    },
+    "Table_Label_0": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_1": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_2": {
+      "expected": "सूचक पर्चा"
+    },
+    "Table_Label_3": {
+      "expected": "सूचक पर्चा"
     }
   }
 }

--- a/testsuite/expected/it/clearspeak/prefix_tables.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Riga 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Caso 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Vincoli 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Equazioni 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Riga 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Riga 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Riga 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/it/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Passo 2, Colonna 2"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   },
   "compare": true

--- a/testsuite/expected/it/mathspeak/prefix_tables.json
+++ b/testsuite/expected/it/mathspeak/prefix_tables.json
@@ -171,6 +171,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2a riga, 2a colonna"
+    },
+    "Table_Label_0": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_1": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_2": {
+      "expected": "Eitchetta"
+    },
+    "Table_Label_3": {
+      "expected": "Eitchetta"
     }
   }
 }

--- a/testsuite/expected/ko/clearspeak/prefix_tables.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2행, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "케이스 2, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "조건문 2, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "방정식 2, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2행, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2행, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2행, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/ko/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2단계, 2열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   },
   "compare": true

--- a/testsuite/expected/ko/mathspeak/prefix_tables.json
+++ b/testsuite/expected/ko/mathspeak/prefix_tables.json
@@ -171,6 +171,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "두번째 행, 두번째 열"
+    },
+    "Table_Label_0": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_1": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_2": {
+      "expected": "꼬리표"
+    },
+    "Table_Label_3": {
+      "expected": "꼬리표"
     }
   }
 }

--- a/testsuite/expected/nb/clearspeak/prefix_tables.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "tilfelle 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "betingelse 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "ligning 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/nb/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "steg 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nb/mathspeak/prefix_tables.json
+++ b/testsuite/expected/nb/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2. Rad, 2. Kolonne"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   }
 }

--- a/testsuite/expected/nn/clearspeak/prefix_tables.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "tilfelle 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "betingelse 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "ligning 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/nn/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "steg 2, Kolonne 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/nn/mathspeak/prefix_tables.json
+++ b/testsuite/expected/nn/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2. Rad, 2. Kolonne"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   }
 }

--- a/testsuite/expected/sv/clearspeak/prefix_tables.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_Case.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_Case.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "fall 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_Constraint.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_Constraint.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "begränsning 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_Equation.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_Equation.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "Ekvation 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_Line.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_Line.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_None.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_None.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_Row.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_Row.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "rad 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/clearspeak/prefix_tables_Step.json
+++ b/testsuite/expected/sv/clearspeak/prefix_tables_Step.json
@@ -175,6 +175,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "steg 2, Kolumn 2"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   },
   "compare": true

--- a/testsuite/expected/sv/mathspeak/prefix_tables.json
+++ b/testsuite/expected/sv/mathspeak/prefix_tables.json
@@ -172,6 +172,18 @@
     },
     "Table_Cell_Depth_5a": {
       "expected": "2:a Raden, 2:a Kolumnen"
+    },
+    "Table_Label_0": {
+      "expected": "Etikett"
+    },
+    "Table_Label_1": {
+      "expected": "Etikett"
+    },
+    "Table_Label_2": {
+      "expected": "Etikett"
+    },
+    "Table_Label_3": {
+      "expected": "Etikett"
     }
   }
 }

--- a/testsuite/input/common/prefix_tables.json
+++ b/testsuite/input/common/prefix_tables.json
@@ -243,6 +243,26 @@
       "grammar": "depth",
       "tex": "\\begin{matrix}a & c \\\\b & d \\end{matrix}",
       "input": "<mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>c</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd><mtd extid=\"A\"><mi>d</mi></mtd></mtr></mtable>"
+    },
+    "Table_Label_0": {
+      "tex": "a\\tag{1}",
+      "id": 1,
+      "input": "<mtable displaystyle=\"true\" data-latex=\"a\\tag{1}\"><mlabeledtr><mtd id=\"mjx-eqn:1\"><mtext data-latex=\"\\text{(1)}\">(1)</mtext></mtd><mtd><mi data-latex=\"\\tag{1}\">a</mi></mtd></mlabeledtr></mtable>"
+    },
+    "Table_Label_1": {
+      "tex": "\\begin{align}a&c\\tag{1}\\end{align}",
+      "id": 1,
+      "input": "<mtable displaystyle=\"true\" columnalign=\"right left\" columnspacing=\"0em\" rowspacing=\"3pt\" data-break-align=\"bottom top\" data-latex-item=\"{align}\" data-latex=\"\\begin{align}a&amp;c\\tag{1}\\end{align}\"><mlabeledtr><mtd id=\"mjx-eqn:1\"><mtext data-latex=\"\\text{(1)}\">(1)</mtext></mtd><mtd><mi data-latex=\"a\">a</mi></mtd><mtd><mstyle indentshift=\"2em\"><mi data-latex=\"\\tag{1}\">c</mi></mstyle></mtd></mlabeledtr></mtable>"
+    },
+    "Table_Label_2": {
+      "tex": "\\begin{align}a&c\\tag{1}\\\\b&d\\tag{2}\\end{align}",
+      "id": 1,
+      "input": "<mtable displaystyle=\"true\" columnalign=\"right left\" columnspacing=\"0em\" rowspacing=\"3pt\" data-break-align=\"bottom top\" data-latex-item=\"{align}\" data-latex=\"\\begin{align}a&amp;c\\tag{1}\\\\b&amp;d\\tag{2}\\end{align}\"><mlabeledtr><mtd id=\"mjx-eqn:1\"><mtext data-latex=\"\\text{(1)}\">(1)</mtext></mtd><mtd><mi data-latex=\"a\">a</mi></mtd><mtd><mstyle indentshift=\"2em\"><mi data-latex=\"\\tag{1}\">c</mi></mstyle></mtd></mlabeledtr><mlabeledtr><mtd id=\"mjx-eqn:2\"><mtext data-latex=\"\\text{(2)}\">(2)</mtext></mtd><mtd><mi data-latex=\"b\">b</mi></mtd><mtd><mstyle indentshift=\"2em\"><mi data-latex=\"\\tag{2}\">d</mi></mstyle></mtd></mlabeledtr></mtable>"
+    },
+    "Table_Label_3": {
+      "tex": "\\begin{align}a&c\\tag{1}\\\\b&d\\tag{2}\\end{align}",
+      "id": 8,
+      "input": "<mtable displaystyle=\"true\" columnalign=\"right left\" columnspacing=\"0em\" rowspacing=\"3pt\" data-break-align=\"bottom top\" data-latex-item=\"{align}\" data-latex=\"\\begin{align}a&amp;c\\tag{1}\\\\b&amp;d\\tag{2}\\end{align}\"><mlabeledtr><mtd id=\"mjx-eqn:1\"><mtext data-latex=\"\\text{(1)}\">(1)</mtext></mtd><mtd><mi data-latex=\"a\">a</mi></mtd><mtd><mstyle indentshift=\"2em\"><mi data-latex=\"\\tag{1}\">c</mi></mstyle></mtd></mlabeledtr><mlabeledtr><mtd id=\"mjx-eqn:2\"><mtext data-latex=\"\\text{(2)}\">(2)</mtext></mtd><mtd><mi data-latex=\"b\">b</mi></mtd><mtd><mstyle indentshift=\"2em\"><mi data-latex=\"\\tag{2}\">d</mi></mstyle></mtd></mlabeledtr></mtable>"
     }
   }
 }


### PR DESCRIPTION
Labels prefixes for clearspeak were incorrect. Now they work.

Adds tests for labels in different multi-line environments.